### PR TITLE
Parser other Hash error

### DIFF
--- a/src/Parse_Unicore_Hash.cpp
+++ b/src/Parse_Unicore_Hash.cpp
@@ -315,9 +315,9 @@ bool sempUnicoreHashFindFirstComma(SEMP_PARSE_STATE *parse, uint8_t data)
         scratchPad->unicoreHash.sentenceName[scratchPad->unicoreHash.sentenceNameLength++] = 0;
 
         // Determine the number of checksum bytes
-        scratchPad->unicoreHash.checksumBytes = 2;
-        if (strstr("VERSION", (const char *)scratchPad->unicoreHash.sentenceName))
-            scratchPad->unicoreHash.checksumBytes = 8;
+        scratchPad->unicoreHash.checksumBytes = 8;
+        if (strstr((const char *)scratchPad->unicoreHash.sentenceName, "MODE") != NULL)
+            scratchPad->unicoreHash.checksumBytes = 2;
         parse->state = sempUnicoreHashFindAsterisk;
     }
     return true;


### PR DESCRIPTION
I see commands in Unicore_Reference_Commands_Manual_For_N4_High_Precision_Products_V2_CH_R1_6, only MODE is two bytes in checksum, others are almost 8 types.
Update checksum bytes for Unicore hash parsing: 8 bytes default, 2 for MODE messages