### PR TITLE
Revert use of PSRAM

### DIFF
--- a/src/SparkFun_Extensible_Message_Parser.cpp
+++ b/src/SparkFun_Extensible_Message_Parser.cpp
@@ -332,7 +332,7 @@ SEMP_PARSE_STATE *sempBeginParser(
         if (usePSRAM == false)
             sempPrintln(printError, "SEMP: PSRAM failed to initialize!");
         else
-            sempPrintf(printDebug, "SEMP: PSRAM Size (bytes): %d\r\n", psramSize);
+            sempPrintf(printError, "SEMP: PSRAM Size (bytes): %d\r\n", psramSize);
 #endif
 
         // Validate the parser address is not nullptr

--- a/src/SparkFun_Extensible_Message_Parser.cpp
+++ b/src/SparkFun_Extensible_Message_Parser.cpp
@@ -78,15 +78,9 @@ SEMP_PARSE_STATE * sempAllocateParseStructure(
     // Allocate the parser
     length = parseBytes + scratchPadBytes;
     if (usePSRAM)
-#if defined(ESP32)
-      parse = (SEMP_PARSE_STATE *)ps_malloc(length + bufferLength);
-#else
-      parse = (SEMP_PARSE_STATE *)malloc(length + bufferLength);
-      sempPrintln(print, "PSRAM: Platform not supported");
-#endif
+        parse = (SEMP_PARSE_STATE *)ps_malloc(length + bufferLength);
     else
-      parse = (SEMP_PARSE_STATE *)malloc(length + bufferLength);
-
+        parse = (SEMP_PARSE_STATE *)malloc(length + bufferLength);
     sempPrintf(printDebug, "parse: %p", (void *)parse);
 
     // Initialize the parse structure

--- a/src/SparkFun_Extensible_Message_Parser.cpp
+++ b/src/SparkFun_Extensible_Message_Parser.cpp
@@ -31,7 +31,6 @@ License: MIT. Please see LICENSE.md for more details
 
 // Allocate the parse structure
 SEMP_PARSE_STATE * sempAllocateParseStructure(
-    bool usePSRAM,
     Print *printDebug,
     uint16_t scratchPadBytes,
     size_t bufferLength
@@ -77,10 +76,7 @@ SEMP_PARSE_STATE * sempAllocateParseStructure(
 
     // Allocate the parser
     length = parseBytes + scratchPadBytes;
-    if (usePSRAM)
-        parse = (SEMP_PARSE_STATE *)ps_malloc(length + bufferLength);
-    else
-        parse = (SEMP_PARSE_STATE *)malloc(length + bufferLength);
+    parse = (SEMP_PARSE_STATE *)malloc(length + bufferLength);
     sempPrintf(printDebug, "parse: %p", (void *)parse);
 
     // Initialize the parse structure
@@ -95,7 +91,6 @@ SEMP_PARSE_STATE * sempAllocateParseStructure(
         sempPrintf(parse->printDebug, "parse->scratchPad: %p", parse->scratchPad);
 
         // Set the buffer address and length
-        parse->usePSRAM = usePSRAM;
         parse->bufferLength = bufferLength;
         parse->buffer = ((uint8_t *)parse->scratchPad + scratchPadBytes);
         sempPrintf(parse->printDebug, "parse->buffer: %p", parse->buffer);
@@ -156,7 +151,6 @@ void sempPrintParserConfiguration(SEMP_PARSE_STATE *parse, Print *print)
                    (void *)parse->buffer, parse->bufferLength);
         sempPrintf(print, "    length: %d message bytes", parse->length);
         sempPrintf(print, "    type: %d (%s)", parse->type, sempGetTypeName(parse, parse->type));
-        sempPrintf(print, "    usePSRAM: %s", parse->usePSRAM ? "true" : "false");
     }
 }
 
@@ -267,8 +261,6 @@ SEMP_PARSE_STATE *sempBeginParser(
     )
 {
     SEMP_PARSE_STATE *parse = nullptr;
-    int psramSize;
-    bool usePSRAM;
 
     do
     {
@@ -314,18 +306,8 @@ SEMP_PARSE_STATE *sempBeginParser(
             break;
         }
 
-        // Attempt to use PSRAM
-        psramSize = 0;
-        if (psramInit())
-            psramSize = ESP.getPsramSize();
-        usePSRAM = (psramSize != 0);
-        if (usePSRAM == false)
-            sempPrintln(printError, "SEMP: PSRAM failed to initialize!");
-        else
-            sempPrintf(printError, "SEMP: PSRAM Size (bytes): %d\r\n", psramSize);
-
         // Validate the parser address is not nullptr
-        parse = sempAllocateParseStructure(usePSRAM, printDebug, scratchPadBytes, bufferLength);
+        parse = sempAllocateParseStructure(printDebug, scratchPadBytes, bufferLength);
         if (!parse)
         {
             sempPrintln(printError, "SEMP: Failed to allocate the parse structure");
@@ -421,12 +403,6 @@ void sempParseNextBytes(SEMP_PARSE_STATE *parse, uint8_t *data, uint16_t len)
         sempParseNextByte(parse, *ptr);
         ptr++;
     }
-}
-
-// Determine if PSRAM is being used by SEMP
-bool sempPsramInUse(const SEMP_PARSE_STATE *parse)
-{
-    return parse->usePSRAM;
 }
 
 // Shutdown the parser

--- a/src/SparkFun_Extensible_Message_Parser.cpp
+++ b/src/SparkFun_Extensible_Message_Parser.cpp
@@ -81,10 +81,8 @@ SEMP_PARSE_STATE * sempAllocateParseStructure(
 #if defined(ESP32)
       parse = (SEMP_PARSE_STATE *)ps_malloc(length + bufferLength);
 #else
-      {
-        parse = (SEMP_PARSE_STATE *)malloc(length + bufferLength);
-        sempPrintln(printDebug, "PSRAM: Platform not supported");
-      }
+      parse = (SEMP_PARSE_STATE *)malloc(length + bufferLength);
+      sempPrintln(print, "PSRAM: Platform not supported");
 #endif
     else
       parse = (SEMP_PARSE_STATE *)malloc(length + bufferLength);
@@ -324,8 +322,6 @@ SEMP_PARSE_STATE *sempBeginParser(
 
         // Attempt to use PSRAM
         psramSize = 0;
-
-#if defined(ESP32)
         if (psramInit())
             psramSize = ESP.getPsramSize();
         usePSRAM = (psramSize != 0);
@@ -333,7 +329,6 @@ SEMP_PARSE_STATE *sempBeginParser(
             sempPrintln(printError, "SEMP: PSRAM failed to initialize!");
         else
             sempPrintf(printError, "SEMP: PSRAM Size (bytes): %d\r\n", psramSize);
-#endif
 
         // Validate the parser address is not nullptr
         parse = sempAllocateParseStructure(usePSRAM, printDebug, scratchPadBytes, bufferLength);

--- a/src/SparkFun_Extensible_Message_Parser.h
+++ b/src/SparkFun_Extensible_Message_Parser.h
@@ -191,7 +191,6 @@ typedef struct _SEMP_PARSE_STATE
                                    // parserCount means searching for preamble
     bool abortNmeaOnNonPrintable;  // Abort NMEA parsing on the arrival of a non-printable char
     bool abortHashOnNonPrintable;  // Abort Unicore hash parsing on the arrival of a non-printable char
-    bool usePSRAM;                 // Enable / disable PSRAM use
 } SEMP_PARSE_STATE;
 
 //----------------------------------------
@@ -411,8 +410,5 @@ bool sempSbfIsEncapsulatedNMEA(const SEMP_PARSE_STATE *parse);
 bool sempSbfIsEncapsulatedRTCMv3(const SEMP_PARSE_STATE *parse);
 uint16_t sempSbfGetEncapsulatedPayloadLength(const SEMP_PARSE_STATE *parse);
 const uint8_t *sempSbfGetEncapsulatedPayload(const SEMP_PARSE_STATE *parse);
-
-// Determine if PSRAM is being used by SEMP
-bool sempPsramInUse(const SEMP_PARSE_STATE *parse);
 
 #endif  // __SPARKFUN_EXTENSIBLE_MESSAGE_PARSER_H__


### PR DESCRIPTION
This PR includes the following commits:
* Revert "Fix print level"
* Revert "Carve out support for ESP32 to avoid compilation errors"
* Revert "Carve out support for ESP32 to avoid compilation errors"
* Revert "Enable the use of PSRAM"