### PR TITLE
Add the scratch pad size to the parser description

### DIFF
--- a/examples/Base_Test/Base_Test.ino
+++ b/examples/Base_Test/Base_Test.ino
@@ -25,6 +25,7 @@ SEMP_PARSER_DESCRIPTION noParserDescription =
 {
     "No parser",            // parserName
     noParserPreamble,       // preamble
+    0,                      // scratchPadBytes
 };
 
 // Build the table listing all of the parsers
@@ -59,55 +60,55 @@ void setup()
 
     // No name specified
     parse = sempBeginParser(nullptr, parserTable, parserCount,
-                            0, buffer, bufferLength, processMessage);
+                            buffer, bufferLength, processMessage);
     if (parse)
         reportFatalError("Failed to detect parserName set to nullptr (0)");
 
     // No name specified
     parse = sempBeginParser("", parserTable, parserCount,
-                            0, buffer, bufferLength, processMessage);
+                            buffer, bufferLength, processMessage);
     if (parse)
         reportFatalError("Failed to detect parserName set to empty string");
 
     // No parser table specified
-    bufferLength = sempGetBufferLength(0, 3000);
+    bufferLength = sempGetBufferLength(parserTable, parserCount, 3000);
     buffer = (uint8_t *)malloc(bufferLength);
     parse = sempBeginParser("No parser", nullptr, parserCount,
-                            0, buffer, bufferLength, processMessage);
+                            buffer, bufferLength, processMessage);
     if (parse)
         reportFatalError("Failed to detect parserTable set to nullptr (0)");
 
     // Parser count is zero
     parse = sempBeginParser("No parser", parserTable, 0,
-                            0, buffer, bufferLength, processMessage);
+                            buffer, bufferLength, processMessage);
     if (parse)
         reportFatalError("Failed because parserCount != nameTableCount");
 
     // No buffer specified
     parse = sempBeginParser("No parser", parserTable, parserCount,
-                            0, nullptr, bufferLength, processMessage);
+                            nullptr, bufferLength, processMessage);
     if (parse)
         reportFatalError("Failed to detect buffer set to nullptr (0)");
 
     // Too small a buffer specified
     parse = sempBeginParser("No parser", parserTable, parserCount,
-                            0, buffer, 0, processMessage);
+                            buffer, 0, processMessage);
     if (parse)
         reportFatalError("Failed to detect buffer set to nullptr (0)");
 
     // No end-of-message callback specified
     parse = sempBeginParser("No parser", parserTable, parserCount,
-                            0, buffer, bufferLength, nullptr);
+                            buffer, bufferLength, nullptr);
     if (parse)
         reportFatalError("Failed to detect eomCallback set to nullptr (0)");
     free(buffer);
 
     // Initialize the parser, specify a large scratch pad area
-    bufferLength = sempGetBufferLength(4091, 3000);
+    bufferLength = sempGetBufferLength(parserTable, parserCount, 3000);
     buffer = (uint8_t *)malloc(bufferLength);
 
     parse = sempBeginParser("Base Test Example", parserTable, parserCount,
-                            4091, buffer, bufferLength, processMessage);
+                            buffer, bufferLength, processMessage);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
     Serial.println("Parser successfully initialized");

--- a/examples/Mixed_Parser/Mixed_Parser.ino
+++ b/examples/Mixed_Parser/Mixed_Parser.ino
@@ -166,10 +166,10 @@ void setup()
     Serial.println();
 
     // Initialize the parser
-    size_t bufferLength = sempGetBufferLength(0, BUFFER_LENGTH);
+    size_t bufferLength = sempGetBufferLength(parserTable, parserCount, BUFFER_LENGTH);
     uint8_t * buffer = (uint8_t *)malloc(bufferLength);
     parse = sempBeginParser("Mixed_Parser", parserTable, parserCount,
-                            0, buffer, bufferLength, processMessage);
+                            buffer, bufferLength, processMessage);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 

--- a/examples/Multiple_Parsers/Multiple_Parsers.ino
+++ b/examples/Multiple_Parsers/Multiple_Parsers.ino
@@ -157,6 +157,7 @@ SEMP_PARSE_STATE *ubloxParser;
 // Initialize the system
 void setup()
 {
+    size_t bufferLength;
     int rawDataBytes;
 
     delay(1000);
@@ -167,15 +168,21 @@ void setup()
     Serial.println();
 
     // Initialize the parsers
-    size_t bufferLength = sempGetBufferLength(0, BUFFER_LENGTH);
+    bufferLength = sempGetBufferLength(nmeaParserTable,
+                                       nmeaParserCount,
+                                       BUFFER_LENGTH);
     uint8_t * buffer1 = (uint8_t *)malloc(bufferLength);
-    uint8_t * buffer2 = (uint8_t *)malloc(bufferLength);
     nmeaParser = sempBeginParser("NMEA_Parser", nmeaParserTable, nmeaParserCount,
-                                 0, buffer1, bufferLength, nmeaSentence);
+                                 buffer1, bufferLength, nmeaSentence);
     if (!nmeaParser)
         reportFatalError("Failed to initialize the NMEA parser");
+
+    bufferLength = sempGetBufferLength(ubloxParserTable,
+                                       ubloxParserCount,
+                                       BUFFER_LENGTH);
+    uint8_t * buffer2 = (uint8_t *)malloc(bufferLength);
     ubloxParser = sempBeginParser("U-Blox_Parser", ubloxParserTable, ubloxParserCount,
-                                  0, buffer2, bufferLength, ubloxMessage);
+                                  buffer2, bufferLength, ubloxMessage);
     if (!ubloxParser)
         reportFatalError("Failed to initialize the U-Blox parser");
 

--- a/examples/NMEA_Test/NMEA_Test.ino
+++ b/examples/NMEA_Test/NMEA_Test.ino
@@ -89,10 +89,10 @@ void setup()
     Serial.println();
 
     // Initialize the parser
-    size_t bufferLength = sempGetBufferLength(0, BUFFER_LENGTH);
+    size_t bufferLength = sempGetBufferLength(parserTable, parserCount, BUFFER_LENGTH);
     uint8_t * buffer = (uint8_t *)malloc(bufferLength);
     parse = sempBeginParser("NMEA_Test", parserTable, parserCount,
-                            0, buffer, bufferLength, processMessage);
+                            buffer, bufferLength, processMessage);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 

--- a/examples/RTCM_Test/RTCM_Test.ino
+++ b/examples/RTCM_Test/RTCM_Test.ino
@@ -85,10 +85,12 @@ void setup()
     Serial.println();
 
     // Initialize the parser
-    size_t bufferLength = sempGetBufferLength(0, BUFFER_LENGTH);
+    size_t bufferLength = sempGetBufferLength(parserTable,
+                                              parserCount,
+                                              BUFFER_LENGTH);
     uint8_t * buffer = (uint8_t *)malloc(bufferLength);
     parse = sempBeginParser("RTCM_Test", parserTable, parserCount,
-                            0, buffer, bufferLength, processMessage);
+                            buffer, bufferLength, processMessage);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 

--- a/examples/SBF_Test/SBF_Test.ino
+++ b/examples/SBF_Test/SBF_Test.ino
@@ -84,10 +84,10 @@ void setup()
     Serial.println();
 
     // Initialize the parser
-    size_t bufferLength = sempGetBufferLength(0, BUFFER_LENGTH);
+    size_t bufferLength = sempGetBufferLength(parserTable, parserCount, BUFFER_LENGTH);
     uint8_t * buffer = (uint8_t *)malloc(bufferLength);
     parse = sempBeginParser("SBF_Test", parserTable, parserCount,
-                            0, buffer, bufferLength, processMessage);
+                            buffer, bufferLength, processMessage);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 
@@ -116,15 +116,13 @@ void loop()
 // Process a complete message incoming from parser
 void processMessage(SEMP_PARSE_STATE *parse, uint16_t type)
 {
-    SEMP_SCRATCH_PAD *scratchPad = (SEMP_SCRATCH_PAD *)parse->scratchPad;
-
     uint32_t offset;
 
     // Display the raw message
     Serial.println();
     offset = dataOffset + 1 - parse->length;
     Serial.printf("Valid SBF message block %d : %d bytes at 0x%08lx (%ld)\r\n",
-                  scratchPad->sbf.sbfID,
+                  sempSbfGetId(parse),
                   parse->length, offset, offset);
     dumpBuffer(parse->buffer, parse->length);
 

--- a/examples/SPARTN_Test/SPARTN_Test.ino
+++ b/examples/SPARTN_Test/SPARTN_Test.ino
@@ -142,10 +142,10 @@ void setup()
     Serial.println();
 
     // Initialize the parser
-    size_t bufferLength = sempGetBufferLength(0, BUFFER_LENGTH);
+    size_t bufferLength = sempGetBufferLength(parserTable, parserCount, BUFFER_LENGTH);
     uint8_t * buffer = (uint8_t *)malloc(bufferLength);
     parse = sempBeginParser("SPARTN_Test", parserTable, parserCount,
-                            0, buffer, bufferLength, processMessage);
+                            buffer, bufferLength, processMessage);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 
@@ -174,9 +174,8 @@ void loop()
 // Process a complete message incoming from parser
 void processMessage(SEMP_PARSE_STATE *parse, uint16_t type)
 {
-    SEMP_SCRATCH_PAD *scratchPad = (SEMP_SCRATCH_PAD *)parse->scratchPad;
-
     static bool displayOnce = true;
+    uint8_t messageType;
     uint32_t offset;
 
     // Display the raw message
@@ -189,10 +188,11 @@ void processMessage(SEMP_PARSE_STATE *parse, uint16_t type)
         "BPAC",
         "EAS"
     };
+    messageType = sempSpartnGetMessageType(parse);
     Serial.printf("Valid SPARTN message, type %d (%s), subtype %d : %d bytes at 0x%08lx (%ld)\r\n",
-                  scratchPad->spartn.messageType,
-                  scratchPad->spartn.messageType <= 4 ? typeName[scratchPad->spartn.messageType] : "TBD / Proprietary",
-                  scratchPad->spartn.messageSubtype,
+                  messageType,
+                  messageType <= 4 ? typeName[messageType] : "TBD / Proprietary",
+                  sempSpartnGetMessageSubType(parse),
                   parse->length, offset, offset);
     dumpBuffer(parse->buffer, parse->length);
 

--- a/examples/UBLOX_Test/UBLOX_Test.ino
+++ b/examples/UBLOX_Test/UBLOX_Test.ino
@@ -135,10 +135,10 @@ void setup()
     Serial.println();
 
     // Initialize the parser
-    size_t bufferLength = sempGetBufferLength(0, BUFFER_LENGTH);
+    size_t bufferLength = sempGetBufferLength(parserTable, parserCount, BUFFER_LENGTH);
     uint8_t * buffer = (uint8_t *)malloc(bufferLength);
     parse = sempBeginParser("UBLOX_Test", parserTable, parserCount,
-                            0, buffer, bufferLength, processMessage);
+                            buffer, bufferLength, processMessage);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 

--- a/examples/Unicore_Binary_Test/Unicore_Binary_Test.ino
+++ b/examples/Unicore_Binary_Test/Unicore_Binary_Test.ino
@@ -132,10 +132,10 @@ void setup()
     Serial.println();
 
     // Initialize the parser
-    size_t bufferLength = sempGetBufferLength(0, BUFFER_LENGTH);
+    size_t bufferLength = sempGetBufferLength(parserTable, parserCount, BUFFER_LENGTH);
     uint8_t * buffer = (uint8_t *)malloc(bufferLength);
     parse = sempBeginParser("Unicore_Test", parserTable, parserCount,
-                            0, buffer, bufferLength, processMessage);
+                            buffer, bufferLength, processMessage);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 

--- a/examples/Unicore_Hash_Test/Unicore_Hash_Test.ino
+++ b/examples/Unicore_Hash_Test/Unicore_Hash_Test.ino
@@ -90,10 +90,10 @@ void setup()
     Serial.println();
 
     // Initialize the parser
-    size_t bufferLength = sempGetBufferLength(0, BUFFER_LENGTH);
+    size_t bufferLength = sempGetBufferLength(parserTable, parserCount, BUFFER_LENGTH);
     uint8_t * buffer = (uint8_t *)malloc(bufferLength);
     parse = sempBeginParser("Unicore_Hash_Test", parserTable, parserCount,
-                            0, buffer, bufferLength, processMessage,
+                            buffer, bufferLength, processMessage,
                             &Serial, nullptr, badUnicoreHashChecksum);
     if (!parse)
         reportFatalError("Failed to initialize the parser");

--- a/examples/User_Parser/User_Parser.ino
+++ b/examples/User_Parser/User_Parser.ino
@@ -134,6 +134,7 @@ SEMP_PARSER_DESCRIPTION userParserDescription =
 {
     "User parser",              // parserName
     userPreamble,               // preamble
+    sizeof(USER_SCRATCH_PAD),
 };
 
 SEMP_PARSER_DESCRIPTION * userParserTable[] =
@@ -166,10 +167,11 @@ void setup()
     Serial.println();
 
     // Initialize the parser
-    size_t bufferLength = sempGetBufferLength(sizeof(USER_SCRATCH_PAD), BUFFER_LENGTH);
+    size_t bufferLength = sempGetBufferLength(userParserTable,
+                                              userParserCount,
+                                              BUFFER_LENGTH);
     uint8_t * buffer = (uint8_t *)malloc(bufferLength);
     parse = sempBeginParser("User_Parser", userParserTable, userParserCount,
-                            sizeof(USER_SCRATCH_PAD),
                             buffer, bufferLength, userMessage);
     if (!parse)
         reportFatalError("Failed to initialize the user parser");

--- a/src/Parse_SBF.cpp
+++ b/src/Parse_SBF.cpp
@@ -297,6 +297,14 @@ int64_t sempSbfGetI8(const SEMP_PARSE_STATE *parse, uint16_t offset)
     unsignedSignedN.unsignedN = sempSbfGetU8(parse, offset);
     return unsignedSignedN.signedN;
 }
+
+// Get the ID value
+uint16_t sempSbfGetId(const SEMP_PARSE_STATE *parse)
+{
+    SEMP_SBF_VALUES * scratchPad = (SEMP_SBF_VALUES *)parse->scratchPad;
+    return scratchPad->sbfID;
+}
+
 float sempSbfGetF4(const SEMP_PARSE_STATE *parse, uint16_t offset)
 {
     union {

--- a/src/Parse_SPARTN.cpp
+++ b/src/Parse_SPARTN.cpp
@@ -301,8 +301,15 @@ const char * sempSpartnGetStateName(const SEMP_PARSE_STATE *parse)
 // Get the message number
 uint8_t sempSpartnGetMessageType(const SEMP_PARSE_STATE *parse)
 {
-    SEMP_SCRATCH_PAD *scratchPad = (SEMP_SCRATCH_PAD *)parse->scratchPad;
-    return scratchPad->spartn.messageType;
+    SEMP_SPARTN_VALUES *scratchPad = (SEMP_SPARTN_VALUES *)parse->scratchPad;
+    return scratchPad->messageType;
+}
+
+// Get the message subtype number
+uint8_t sempSpartnGetMessageSubType(const SEMP_PARSE_STATE *parse)
+{
+    SEMP_SPARTN_VALUES *scratchPad = (SEMP_SPARTN_VALUES *)parse->scratchPad;
+    return scratchPad->messageSubtype;
 }
 
 // Describe the parser

--- a/src/Parse_SPARTN.cpp
+++ b/src/Parse_SPARTN.cpp
@@ -18,20 +18,42 @@ License: MIT. Please see LICENSE.md for more details
 #include "semp_crc_spartn.h" // 4/8/16/24/32-bit cyclic redundancy checksums for SPARTN parsing
 
 //----------------------------------------
+// Types
+//----------------------------------------
+
+// SPARTN parser scratch area
+typedef struct _SEMP_SPARTN_VALUES
+{
+    uint16_t frameCount;
+    uint16_t crcBytes;
+    uint16_t TF007toTF016;
+
+    uint8_t messageType;
+    uint16_t payloadLength;
+    uint16_t EAF;
+    uint8_t crcType;
+    uint8_t frameCRC;
+    uint8_t messageSubtype;
+    uint16_t timeTagType;
+    uint16_t authenticationIndicator;
+    uint16_t embeddedApplicationLengthBytes;
+} SEMP_SPARTN_VALUES;
+
+//----------------------------------------
 // SPARTN parse routines
 //----------------------------------------
 
 bool sempSpartnReadTF018(SEMP_PARSE_STATE *parse, uint8_t data)
 {
-    SEMP_SCRATCH_PAD *scratchPad = (SEMP_SCRATCH_PAD *)parse->scratchPad;
+    SEMP_SPARTN_VALUES *scratchPad = (SEMP_SPARTN_VALUES *)parse->scratchPad;
 
-    scratchPad->spartn.frameCount++;
-    if (scratchPad->spartn.frameCount == scratchPad->spartn.crcBytes)
+    scratchPad->frameCount++;
+    if (scratchPad->frameCount == scratchPad->crcBytes)
     {
-        uint16_t numBytes = 4 + scratchPad->spartn.TF007toTF016 + scratchPad->spartn.payloadLength + scratchPad->spartn.embeddedApplicationLengthBytes;
+        uint16_t numBytes = 4 + scratchPad->TF007toTF016 + scratchPad->payloadLength + scratchPad->embeddedApplicationLengthBytes;
         uint8_t *ptr = &parse->buffer[numBytes];
         bool valid;
-        switch (scratchPad->spartn.crcType)
+        switch (scratchPad->crcType)
         {
         case 0:
         {
@@ -84,8 +106,8 @@ bool sempSpartnReadTF018(SEMP_PARSE_STATE *parse, uint8_t data)
             sempPrintf(parse->printDebug,
                     "SEMP %s: SPARTN %d %d, 0x%04x (%d) bytes, bad CRC",
                     parse->parserName,
-                    scratchPad->spartn.messageType,
-                    scratchPad->spartn.messageSubtype,
+                    scratchPad->messageType,
+                    scratchPad->messageSubtype,
                     parse->length, parse->length);
         parse->state = sempFirstByte;
         return false;
@@ -96,13 +118,13 @@ bool sempSpartnReadTF018(SEMP_PARSE_STATE *parse, uint8_t data)
 
 bool sempSpartnReadTF017(SEMP_PARSE_STATE *parse, uint8_t data)
 {
-    SEMP_SCRATCH_PAD *scratchPad = (SEMP_SCRATCH_PAD *)parse->scratchPad;
+    SEMP_SPARTN_VALUES *scratchPad = (SEMP_SPARTN_VALUES *)parse->scratchPad;
 
-    scratchPad->spartn.frameCount++;
-    if (scratchPad->spartn.frameCount == scratchPad->spartn.embeddedApplicationLengthBytes)
+    scratchPad->frameCount++;
+    if (scratchPad->frameCount == scratchPad->embeddedApplicationLengthBytes)
     {
         parse->state = sempSpartnReadTF018;
-        scratchPad->spartn.frameCount = 0;
+        scratchPad->frameCount = 0;
     }
 
     return true;
@@ -110,20 +132,20 @@ bool sempSpartnReadTF017(SEMP_PARSE_STATE *parse, uint8_t data)
 
 bool sempSpartnReadTF016(SEMP_PARSE_STATE *parse, uint8_t data)
 {
-    SEMP_SCRATCH_PAD *scratchPad = (SEMP_SCRATCH_PAD *)parse->scratchPad;
+    SEMP_SPARTN_VALUES *scratchPad = (SEMP_SPARTN_VALUES *)parse->scratchPad;
 
-    scratchPad->spartn.frameCount++;
-    if (scratchPad->spartn.frameCount == scratchPad->spartn.payloadLength)
+    scratchPad->frameCount++;
+    if (scratchPad->frameCount == scratchPad->payloadLength)
     {
-        if (scratchPad->spartn.embeddedApplicationLengthBytes > 0)
+        if (scratchPad->embeddedApplicationLengthBytes > 0)
         {
             parse->state = sempSpartnReadTF017;
-            scratchPad->spartn.frameCount = 0;
+            scratchPad->frameCount = 0;
         }
         else
         {
             parse->state = sempSpartnReadTF018;
-            scratchPad->spartn.frameCount = 0;
+            scratchPad->frameCount = 0;
         }
     }
 
@@ -132,44 +154,44 @@ bool sempSpartnReadTF016(SEMP_PARSE_STATE *parse, uint8_t data)
 
 bool sempSpartnReadTF009(SEMP_PARSE_STATE *parse, uint8_t data)
 {
-    SEMP_SCRATCH_PAD *scratchPad = (SEMP_SCRATCH_PAD *)parse->scratchPad;
+    SEMP_SPARTN_VALUES *scratchPad = (SEMP_SPARTN_VALUES *)parse->scratchPad;
 
-    scratchPad->spartn.frameCount++;
-    if (scratchPad->spartn.frameCount == scratchPad->spartn.TF007toTF016)
+    scratchPad->frameCount++;
+    if (scratchPad->frameCount == scratchPad->TF007toTF016)
     {
-        if (scratchPad->spartn.EAF == 0)
+        if (scratchPad->EAF == 0)
         {
-            scratchPad->spartn.authenticationIndicator = 0;
-            scratchPad->spartn.embeddedApplicationLengthBytes = 0;
+            scratchPad->authenticationIndicator = 0;
+            scratchPad->embeddedApplicationLengthBytes = 0;
         }
         else
         {
-            scratchPad->spartn.authenticationIndicator = (data >> 3) & 0x07;
-            if (scratchPad->spartn.authenticationIndicator <= 1)
-                scratchPad->spartn.embeddedApplicationLengthBytes = 0;
+            scratchPad->authenticationIndicator = (data >> 3) & 0x07;
+            if (scratchPad->authenticationIndicator <= 1)
+                scratchPad->embeddedApplicationLengthBytes = 0;
             else
             {
                 switch (data & 0x07)
                 {
                 case 0:
-                    scratchPad->spartn.embeddedApplicationLengthBytes = 8; // 64 bits
+                    scratchPad->embeddedApplicationLengthBytes = 8; // 64 bits
                     break;
                 case 1:
-                    scratchPad->spartn.embeddedApplicationLengthBytes = 12; // 96 bits
+                    scratchPad->embeddedApplicationLengthBytes = 12; // 96 bits
                     break;
                 case 2:
-                    scratchPad->spartn.embeddedApplicationLengthBytes = 16; // 128 bits
+                    scratchPad->embeddedApplicationLengthBytes = 16; // 128 bits
                     break;
                 case 3:
-                    scratchPad->spartn.embeddedApplicationLengthBytes = 32; // 256 bits
+                    scratchPad->embeddedApplicationLengthBytes = 32; // 256 bits
                     break;
                 default:
-                    scratchPad->spartn.embeddedApplicationLengthBytes = 64; // 512 / TBD bits
+                    scratchPad->embeddedApplicationLengthBytes = 64; // 512 / TBD bits
                     break;
                 }
             }
         }
-        scratchPad->spartn.frameCount = 0;
+        scratchPad->frameCount = 0;
         parse->state = sempSpartnReadTF016;
     }
 
@@ -178,17 +200,17 @@ bool sempSpartnReadTF009(SEMP_PARSE_STATE *parse, uint8_t data)
 
 bool sempSpartnReadTF007(SEMP_PARSE_STATE *parse, uint8_t data)
 {
-    SEMP_SCRATCH_PAD *scratchPad = (SEMP_SCRATCH_PAD *)parse->scratchPad;
+    SEMP_SPARTN_VALUES *scratchPad = (SEMP_SPARTN_VALUES *)parse->scratchPad;
 
-    scratchPad->spartn.messageSubtype = data >> 4;
-    scratchPad->spartn.timeTagType = (data >> 3) & 0x01;
-    if (scratchPad->spartn.timeTagType == 0)
-        scratchPad->spartn.TF007toTF016 = 4;
+    scratchPad->messageSubtype = data >> 4;
+    scratchPad->timeTagType = (data >> 3) & 0x01;
+    if (scratchPad->timeTagType == 0)
+        scratchPad->TF007toTF016 = 4;
     else
-        scratchPad->spartn.TF007toTF016 = 6;
-    if (scratchPad->spartn.EAF > 0)
-        scratchPad->spartn.TF007toTF016 += 2;
-    scratchPad->spartn.frameCount = 1;
+        scratchPad->TF007toTF016 = 6;
+    if (scratchPad->EAF > 0)
+        scratchPad->TF007toTF016 += 2;
+    scratchPad->frameCount = 1;
 
     parse->state = sempSpartnReadTF009;
 
@@ -197,51 +219,51 @@ bool sempSpartnReadTF007(SEMP_PARSE_STATE *parse, uint8_t data)
 
 bool sempSpartnReadTF002TF006(SEMP_PARSE_STATE *parse, uint8_t data)
 {
-    SEMP_SCRATCH_PAD *scratchPad = (SEMP_SCRATCH_PAD *)parse->scratchPad;
+    SEMP_SPARTN_VALUES *scratchPad = (SEMP_SPARTN_VALUES *)parse->scratchPad;
 
-    if (scratchPad->spartn.frameCount == 0)
+    if (scratchPad->frameCount == 0)
     {
-        scratchPad->spartn.messageType = data >> 1;
-        scratchPad->spartn.payloadLength = data & 0x01;
+        scratchPad->messageType = data >> 1;
+        scratchPad->payloadLength = data & 0x01;
     }
-    if (scratchPad->spartn.frameCount == 1)
+    if (scratchPad->frameCount == 1)
     {
-        scratchPad->spartn.payloadLength <<= 8;
-        scratchPad->spartn.payloadLength |= data;
+        scratchPad->payloadLength <<= 8;
+        scratchPad->payloadLength |= data;
     }
-    if (scratchPad->spartn.frameCount == 2)
+    if (scratchPad->frameCount == 2)
     {
-        scratchPad->spartn.payloadLength <<= 1;
-        scratchPad->spartn.payloadLength |= data >> 7;
-        scratchPad->spartn.EAF = (data >> 6) & 0x01;
-        scratchPad->spartn.crcType = (data >> 4) & 0x03;
-        switch (scratchPad->spartn.crcType)
+        scratchPad->payloadLength <<= 1;
+        scratchPad->payloadLength |= data >> 7;
+        scratchPad->EAF = (data >> 6) & 0x01;
+        scratchPad->crcType = (data >> 4) & 0x03;
+        switch (scratchPad->crcType)
         {
         case 0:
-            scratchPad->spartn.crcBytes = 1;
+            scratchPad->crcBytes = 1;
             break;
         case 1:
-            scratchPad->spartn.crcBytes = 2;
+            scratchPad->crcBytes = 2;
             break;
         case 2:
-            scratchPad->spartn.crcBytes = 3;
+            scratchPad->crcBytes = 3;
             break;
         default:
-            scratchPad->spartn.crcBytes = 4;
+            scratchPad->crcBytes = 4;
             break;
         }
-        scratchPad->spartn.frameCRC = data & 0x0F;
+        scratchPad->frameCRC = data & 0x0F;
         parse->buffer[3] = parse->buffer[3] & 0xF0; // Zero the 4 LSBs before calculating the CRC
-        if (semp_uSpartnCrc4(&parse->buffer[1], 3) == scratchPad->spartn.frameCRC)
+        if (semp_uSpartnCrc4(&parse->buffer[1], 3) == scratchPad->frameCRC)
         {
             parse->buffer[3] = data; // Restore TF005 and TF006 now we know the data is valid
             if (parse->verboseDebug)
                 sempPrintf(parse->printDebug,
                         "SEMP %s: Incoming SPARTN %d %d, 0x%04x (%d) bytes",
                         parse->parserName,
-                        scratchPad->spartn.messageType,
-                        scratchPad->spartn.messageSubtype,
-                        scratchPad->spartn.payloadLength, scratchPad->spartn.payloadLength);
+                        scratchPad->messageType,
+                        scratchPad->messageSubtype,
+                        scratchPad->payloadLength, scratchPad->payloadLength);
             parse->state = sempSpartnReadTF007;
         }
         else
@@ -253,25 +275,25 @@ bool sempSpartnReadTF002TF006(SEMP_PARSE_STATE *parse, uint8_t data)
             sempPrintf(parse->printDebug,
                     "SEMP %s: SPARTN %d, 0x%04x (%d) bytes, bad header CRC",
                     parse->parserName,
-                    scratchPad->spartn.messageType,
+                    scratchPad->messageType,
                     parse->length, parse->length);
 
             return false;
         }
     }
 
-    scratchPad->spartn.frameCount++;
+    scratchPad->frameCount++;
     return true;
 }
 
 // Check for the preamble
 bool sempSpartnPreamble(SEMP_PARSE_STATE *parse, uint8_t data)
 {
-    SEMP_SCRATCH_PAD *scratchPad = (SEMP_SCRATCH_PAD *)parse->scratchPad;
+    SEMP_SPARTN_VALUES *scratchPad = (SEMP_SPARTN_VALUES *)parse->scratchPad;
 
     if (data == 0x73)
     {
-        scratchPad->spartn.frameCount = 0;
+        scratchPad->frameCount = 0;
         parse->state = sempSpartnReadTF002TF006;
         return true;
     }
@@ -317,4 +339,5 @@ SEMP_PARSER_DESCRIPTION sempSpartnParserDescription =
 {
     "SPARTN parser",            // parserName
     sempSpartnPreamble,         // preamble
+    sizeof(SEMP_SPARTN_VALUES), // scratchPadBytes
 };

--- a/src/SparkFun_Extensible_Message_Parser.h
+++ b/src/SparkFun_Extensible_Message_Parser.h
@@ -570,8 +570,31 @@ void sempSbfSetInvalidDataCallback(const SEMP_PARSE_STATE *parse, SEMP_INVALID_D
 
 extern SEMP_PARSER_DESCRIPTION sempSpartnParserDescription;
 
-// SPARTN parse routines
+// Get the message number
+//
+// Inputs:
+//   parse: Address of a SEMP_PARSE_STATE structure
+//
+// Outputs:
+//    Returns the message type number
 uint8_t sempSpartnGetMessageType(const SEMP_PARSE_STATE *parse);
+
+// Get the message subtype number
+//
+// Inputs:
+//   parse: Address of a SEMP_PARSE_STATE structure
+//
+// Outputs:
+//    Returns the message subtype number
+uint8_t sempSpartnGetMessageSubType(const SEMP_PARSE_STATE *parse);
+
+// Translates state value into an string, returns nullptr if not found
+//
+// Inputs:
+//   parse: Address of a SEMP_PARSE_STATE structure
+//
+// Outputs:
+//    Returns a zero terminated string of characters
 const char * sempSpartnGetStateName(const SEMP_PARSE_STATE *parse);
 
 // Start the parser by processing the first byte of data

--- a/src/SparkFun_Extensible_Message_Parser.h
+++ b/src/SparkFun_Extensible_Message_Parser.h
@@ -543,6 +543,15 @@ int8_t sempSbfGetI1(const SEMP_PARSE_STATE *parse, uint16_t offset);
 int16_t sempSbfGetI2(const SEMP_PARSE_STATE *parse, uint16_t offset);
 int32_t sempSbfGetI4(const SEMP_PARSE_STATE *parse, uint16_t offset);
 int64_t sempSbfGetI8(const SEMP_PARSE_STATE *parse, uint16_t offset);
+
+// Get the ID value
+//
+// Inputs:
+//   parse: Address of a SEMP_PARSE_STATE structure
+//
+// Outputs:
+//    Returns the ID value
+uint16_t sempSbfGetId(const SEMP_PARSE_STATE *parse);
 const char * sempSbfGetStateName(const SEMP_PARSE_STATE *parse);
 const char *sempSbfGetString(const SEMP_PARSE_STATE *parse, uint16_t offset);
 uint8_t sempSbfGetU1(const SEMP_PARSE_STATE *parse, uint16_t offset);


### PR DESCRIPTION
This PR include the following commits:
* Add sempSpartnGetMessageSubType
* Add sempSbfGetId
* Don't expose the scratch pad area