### PR TITLE
Add the generic print routines and replace printDebug

### DIFF
--- a/examples/Base_Test/Base_Test.ino
+++ b/examples/Base_Test/Base_Test.ino
@@ -145,7 +145,7 @@ void setup()
     // Display the parser configuration
     sempPrintString(output, "&parserTable: ");
     sempPrintAddrLn(output, parserTable);
-    sempPrintParserConfiguration(parse, &Serial);
+    sempPrintParserConfiguration(parse, output);
 
     // Display the parse state
     sempPrintString(output, "Parse State: ");
@@ -204,6 +204,6 @@ void processMessage(SEMP_PARSE_STATE *parse, uint16_t type)
     {
         displayOnce = false;
         sempPrintLn(output);
-        sempPrintParserConfiguration(parse, &Serial);
+        sempPrintParserConfiguration(parse, output);
     }
 }

--- a/examples/Base_Test/Base_Test.ino
+++ b/examples/Base_Test/Base_Test.ino
@@ -156,7 +156,7 @@ void setup()
     sempPrintStringLn(output, sempGetTypeName(parse, parse->type));
 
     // Obtain a raw data stream from somewhere
-    sempEnableDebugOutput(parse);
+    sempDebugOutputEnable(parse);
     sempPrintString(output, "Raw data stream: ");
     sempPrintDecimalI32(output, RAW_DATA_BYTES);
     sempPrintStringLn(output, " bytes");

--- a/examples/Common/dumpBuffer.ino
+++ b/examples/Common/dumpBuffer.ino
@@ -30,29 +30,33 @@ void dumpBuffer(const uint8_t *buffer, size_t length)
             bytes = 16 - (offset & 0xf);
 
         // Display the offset
-        Serial.printf("0x%08lx: ", offset);
+        sempPrintHex0x08x(output, offset);
+        sempPrintString(output, ": ");
 
         // Skip leading bytes
         for (index = 0; index < (offset & 0xf); index++)
-            Serial.printf("   ");
+            sempPrintString(output, "   ");
 
         // Display the data bytes
         for (index = 0; index < bytes; index++)
-            Serial.printf("%02x ", buffer[index]);
+        {
+            sempPrintHex02x(output, buffer[index]);
+            output(' ');
+        }
 
         // Separate the data bytes from the ASCII
         for (; index < (16 - (offset & 0xf)); index++)
-            Serial.printf("   ");
-        Serial.printf(" ");
+            sempPrintString(output, "   ");
+        sempPrintString(output, " ");
 
         // Skip leading bytes
         for (index = 0; index < (offset & 0xf); index++)
-            Serial.printf(" ");
+            sempPrintString(output, " ");
 
         // Display the ASCII values
         for (index = 0; index < bytes; index++)
-            Serial.printf("%c", ((buffer[index] < ' ') || (buffer[index] >= 0x7f)) ? '.' : buffer[index]);
-        Serial.printf("\r\n");
+            output(((buffer[index] < ' ') || (buffer[index] >= 0x7f)) ? '.' : buffer[index]);
+        sempPrintLn(output);
 
         // Set the next line of data
         buffer += bytes;

--- a/examples/Common/output.ino
+++ b/examples/Common/output.ino
@@ -1,0 +1,22 @@
+/*
+  output.ino
+
+  Output a single character to the serial port
+
+  License: MIT. Please see LICENSE.md for more details
+*/
+
+//----------------------------------------
+// Output a character
+//
+// Inputs:
+//   character: The character to output
+//----------------------------------------
+void output(char character)
+{
+    // Wait until space is available in the FIFO
+    while (Serial.availableForWrite() == 0);
+
+    // Output the character
+    Serial.write(character);
+}

--- a/examples/Common/reportFatalError.ino
+++ b/examples/Common/reportFatalError.ino
@@ -16,9 +16,8 @@ void reportFatalError(const char *errorMsg)
 {
     while (1)
     {
-        Serial.print("HALTED: ");
-        Serial.print(errorMsg);
-        Serial.println();
-        sleep(15);
+        sempPrintString(output, "HALTED: ");
+        sempPrintStringLn(output, errorMsg);
+        delay(15 * 1000);   // sleep(15);
     }
 }

--- a/examples/Mixed_Parser/Mixed_Parser.ino
+++ b/examples/Mixed_Parser/Mixed_Parser.ino
@@ -273,6 +273,6 @@ void processMessage(SEMP_PARSE_STATE *parse, uint16_t type)
     {
         displayOnce = false;
         sempPrintLn(output);
-        sempPrintParserConfiguration(parse, &Serial);
+        sempPrintParserConfiguration(parse, output);
     }
 }

--- a/examples/Mixed_Parser/Mixed_Parser.ino
+++ b/examples/Mixed_Parser/Mixed_Parser.ino
@@ -200,7 +200,7 @@ void setup()
     sempPrintStringLn(output, " bytes");
 
     // The raw data stream is passed to the parser one byte at a time
-    sempEnableDebugOutput(parse);
+    sempDebugOutputEnable(parse);
     for (dataIndex = 0; dataIndex < DATA_STREAM_ENTRIES; dataIndex++)
     {
         for (byteOffset = 0; byteOffset < dataStream[dataIndex].length; byteOffset++)

--- a/examples/Mixed_Parser/Mixed_Parser.ino
+++ b/examples/Mixed_Parser/Mixed_Parser.ino
@@ -15,6 +15,7 @@
 
 #include <SparkFun_Extensible_Message_Parser.h> //http://librarymanager/All#SparkFun_Extensible_Message_Parser
 
+#include "../Common/output.ino"
 #include "../Common/dumpBuffer.ino"
 #include "../Common/reportFatalError.ino"
 
@@ -171,21 +172,22 @@ void setup()
     delay(1000);
 
     Serial.begin(115200);
-    Serial.println();
-    Serial.println("Mixed_Parser example sketch");
-    Serial.println();
+    sempPrintLn(output);
+    sempPrintStringLn(output, "Mixed_Parser example sketch");
+    sempPrintLn(output);
 
     // Verify the buffer size
     bufferLength = sempGetBufferLength(parserTable, parserCount);
     if (sizeof(buffer) < bufferLength)
     {
-        Serial.printf("Set buffer size to >= %d\r\n", bufferLength);
+        sempPrintString(output, "Set buffer size to >= ");
+        sempPrintDecimalI32Ln(output, bufferLength);
         reportFatalError("Fix the buffer size!");
     }
 
     // Initialize the parser
     parse = sempBeginParser("Mixed_Parser", parserTable, parserCount,
-                            buffer, bufferLength, processMessage);
+                            buffer, bufferLength, processMessage, output);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 
@@ -193,7 +195,9 @@ void setup()
     rawDataBytes = 0;
     for (dataIndex = 0; dataIndex < DATA_STREAM_ENTRIES; dataIndex++)
         rawDataBytes += dataStream[dataIndex].length;
-    Serial.printf("Raw data stream: %d bytes\r\n", rawDataBytes);
+    sempPrintString(output, "Raw data stream: ");
+    sempPrintDecimalI32(output,rawDataBytes);
+    sempPrintStringLn(output, " bytes");
 
     // The raw data stream is passed to the parser one byte at a time
     sempEnableDebugOutput(parse);
@@ -209,7 +213,7 @@ void setup()
 
     // Done parsing the data
     sempStopParser(&parse);
-    Serial.printf("All done\r\n");
+    sempPrintStringLn(output, "All done");
 }
 
 //----------------------------------------
@@ -230,7 +234,7 @@ void processMessage(SEMP_PARSE_STATE *parse, uint16_t type)
     uint32_t offset;
 
     // Display the raw message
-    Serial.println();
+    sempPrintLn(output);
     switch (type) // Index into parserTable array
     {
         case NMEA_PARSER_INDEX:
@@ -242,14 +246,24 @@ void processMessage(SEMP_PARSE_STATE *parse, uint16_t type)
                 offset -= 1;
                 byteIndex -= 1;
             }
-            Serial.printf("Valid NMEA Sentence: %s, %d bytes at 0x%08x (%d)\r\n",
-                          sempNmeaGetSentenceName(parse), parse->length, offset, offset);
+            sempPrintString(output, "Valid NMEA Sentence: ");
+            sempPrintString(output,sempNmeaGetSentenceName(parse));
+            sempPrintString(output, ", ");
+            sempPrintDecimalI32(output, parse->length);
+            sempPrintString(output, " bytes at ");
+            sempPrintHex0x08x(output, offset);
+            sempPrintString(output, " (");
+            sempPrintDecimalI32Ln(output, offset);
             break;
 
         case UBLOX_PARSER_INDEX:
             offset = dataOffset + 1 - parse->length;
-            Serial.printf("Valid u-blox message: %d bytes at 0x%08x (%d)\r\n",
-                          parse->length, offset, offset);
+            sempPrintString(output, "Valid u-blox message: ");
+            sempPrintDecimalI32(output, parse->length);
+            sempPrintString(output, " bytes at ");
+            sempPrintHex0x08x(output, offset);
+            sempPrintString(output, " (");
+            sempPrintDecimalI32Ln(output, offset);
             break;
     }
     dumpBuffer(parse->buffer, parse->length);
@@ -258,7 +272,7 @@ void processMessage(SEMP_PARSE_STATE *parse, uint16_t type)
     if (displayOnce)
     {
         displayOnce = false;
-        Serial.println();
+        sempPrintLn(output);
         sempPrintParserConfiguration(parse, &Serial);
     }
 }

--- a/examples/Multiple_Parsers/Multiple_Parsers.ino
+++ b/examples/Multiple_Parsers/Multiple_Parsers.ino
@@ -212,8 +212,8 @@ void setup()
     sempPrintStringLn(output, " bytes");
 
     // The raw data stream is passed to the parser one byte at a time
-    sempEnableDebugOutput(nmeaParser);
-    sempEnableDebugOutput(ubloxParser);
+    sempDebugOutputEnable(nmeaParser);
+    sempDebugOutputEnable(ubloxParser);
     for (dataIndex = 0; dataIndex < DATA_STREAM_ENTRIES; dataIndex++)
     {
         for (byteOffset = 0; byteOffset < dataStream[dataIndex].length; byteOffset++)

--- a/examples/Multiple_Parsers/Multiple_Parsers.ino
+++ b/examples/Multiple_Parsers/Multiple_Parsers.ino
@@ -275,7 +275,7 @@ void nmeaSentence(SEMP_PARSE_STATE *parse, uint16_t type)
     {
         displayOnce = false;
         sempPrintLn(output);
-        sempPrintParserConfiguration(parse, &Serial);
+        sempPrintParserConfiguration(parse, output);
     }
 }
 
@@ -304,6 +304,6 @@ void ubloxMessage(SEMP_PARSE_STATE *parse, uint16_t type)
     {
         displayOnce = false;
         sempPrintLn(output);
-        sempPrintParserConfiguration(parse, &Serial);
+        sempPrintParserConfiguration(parse, output);
     }
 }

--- a/examples/NMEA_Test/NMEA_Test.ino
+++ b/examples/NMEA_Test/NMEA_Test.ino
@@ -177,7 +177,7 @@ void processMessage(SEMP_PARSE_STATE *parse, uint16_t type)
     {
         displayOnce = false;
         sempPrintLn(output);
-        sempPrintParserConfiguration(parse, &Serial);
+        sempPrintParserConfiguration(parse, output);
     }
 }
 

--- a/examples/NMEA_Test/NMEA_Test.ino
+++ b/examples/NMEA_Test/NMEA_Test.ino
@@ -8,6 +8,7 @@
 
 #include <SparkFun_Extensible_Message_Parser.h> //http://librarymanager/All#SparkFun_Extensible_Message_Parser
 
+#include "../Common/output.ino"
 #include "../Common/dumpBuffer.ino"
 #include "../Common/reportFatalError.ino"
 
@@ -99,21 +100,22 @@ void setup()
     delay(1000);
 
     Serial.begin(115200);
-    Serial.println();
-    Serial.println("NMEA_Test_example sketch");
-    Serial.println();
+    sempPrintLn(output);
+    sempPrintStringLn(output, "NMEA_Test_example sketch");
+    sempPrintLn(output);
 
     // Verify the buffer size
     bufferLength = sempGetBufferLength(parserTable, parserCount);
     if (sizeof(buffer) < bufferLength)
     {
-        Serial.printf("Set buffer size to >= %d\r\n", bufferLength);
+        sempPrintString(output, "Set buffer size to >= ");
+        sempPrintDecimalI32Ln(output, bufferLength);
         reportFatalError("Fix the buffer size!");
     }
 
     // Initialize the parser
     parse = sempBeginParser("NMEA_Test", parserTable, parserCount,
-                            buffer, bufferLength, processMessage);
+                            buffer, bufferLength, processMessage, output);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 
@@ -121,7 +123,9 @@ void setup()
     sempSetInvalidDataCallback(parse, invalidData);
 
     // Obtain a raw data stream from somewhere
-    Serial.printf("Raw data stream: %d bytes\r\n", RAW_DATA_BYTES);
+    sempPrintString(output, "Raw data stream: ");
+    sempPrintDecimalI32(output, RAW_DATA_BYTES);
+    sempPrintStringLn(output, " bytes");
 
     // The raw data stream is passed to the parser one byte at a time
     sempEnableDebugOutput(parse);
@@ -131,7 +135,7 @@ void setup()
 
     // Done parsing the data
     sempStopParser(&parse);
-    Serial.printf("All done\r\n");
+    sempPrintStringLn(output, "All done");
 }
 
 //----------------------------------------
@@ -156,16 +160,23 @@ void processMessage(SEMP_PARSE_STATE *parse, uint16_t type)
         offset -= 1;
 
     // Display the raw message
-    Serial.println();
-    Serial.printf("Valid NMEA Sentence: %s, %d bytes at 0x%08x (%d)\r\n",
-                  sempNmeaGetSentenceName(parse), parse->length, offset, offset);
+    sempPrintLn(output);
+    sempPrintString(output, "Valid NMEA Sentence: ");
+    sempPrintString(output, sempNmeaGetSentenceName(parse));
+    sempPrintString(output, ", ");
+    sempPrintDecimalI32(output, parse->length);
+    sempPrintString(output, " bytes at ");
+    sempPrintHex0x08x(output, offset);
+    sempPrintString(output, " (");
+    sempPrintDecimalI32(output, offset);
+    sempPrintCharLn(output, ')');
     dumpBuffer(parse->buffer, parse->length);
 
     // Display the parser state
     if (displayOnce)
     {
         displayOnce = false;
-        Serial.println();
+        sempPrintLn(output);
         sempPrintParserConfiguration(parse, &Serial);
     }
 }
@@ -176,6 +187,6 @@ void processMessage(SEMP_PARSE_STATE *parse, uint16_t type)
 void invalidData(const uint8_t * buffer, size_t length)
 {
     // Display the invalid data
-    Serial.printf("Invalid data:\r\n");
+    sempPrintStringLn(output, "Invalid data:");
     dumpBuffer(buffer, length);
 }

--- a/examples/NMEA_Test/NMEA_Test.ino
+++ b/examples/NMEA_Test/NMEA_Test.ino
@@ -128,7 +128,7 @@ void setup()
     sempPrintStringLn(output, " bytes");
 
     // The raw data stream is passed to the parser one byte at a time
-    sempEnableDebugOutput(parse);
+    sempDebugOutputEnable(parse);
     for (dataOffset = 0; dataOffset < RAW_DATA_BYTES; dataOffset++)
         // Update the parser state based on the incoming byte
         sempParseNextByte(parse, rawDataStream[dataOffset]);

--- a/examples/RTCM_Test/RTCM_Test.ino
+++ b/examples/RTCM_Test/RTCM_Test.ino
@@ -169,6 +169,6 @@ void processMessage(SEMP_PARSE_STATE *parse, uint16_t type)
     {
         displayOnce = false;
         sempPrintLn(output);
-        sempPrintParserConfiguration(parse, &Serial);
+        sempPrintParserConfiguration(parse, output);
     }
 }

--- a/examples/RTCM_Test/RTCM_Test.ino
+++ b/examples/RTCM_Test/RTCM_Test.ino
@@ -112,7 +112,7 @@ void setup()
     sempPrintStringLn(output, " bytes");
 
     // The raw data stream is passed to the parser one byte at a time
-    sempEnableDebugOutput(parse);
+    sempDebugOutputEnable(parse);
     for (dataOffset = 0; dataOffset < RAW_DATA_BYTES; dataOffset++)
         // Update the parser state based on the incoming byte
         sempParseNextByte(parse, rawDataStream[dataOffset]);

--- a/examples/SBF_Test/SBF_Test.ino
+++ b/examples/SBF_Test/SBF_Test.ino
@@ -174,6 +174,6 @@ void processMessage(SEMP_PARSE_STATE *parse, uint16_t type)
     {
         displayOnce = false;
         sempPrintLn(output);
-        sempPrintParserConfiguration(parse, &Serial);
+        sempPrintParserConfiguration(parse, output);
     }
 }

--- a/examples/SBF_Test/SBF_Test.ino
+++ b/examples/SBF_Test/SBF_Test.ino
@@ -111,7 +111,7 @@ void setup()
     sempPrintStringLn(output, " bytes");
 
     // The raw data stream is passed to the parser one byte at a time
-    sempEnableDebugOutput(parse);
+    sempDebugOutputEnable(parse);
     for (dataOffset = 0; dataOffset < RAW_DATA_BYTES; dataOffset++)
         // Update the parser state based on the incoming byte
         sempParseNextByte(parse, rawDataStream[dataOffset]);

--- a/examples/SBF_in_SPARTN_Test/SBF_in_SPARTN_Test.ino
+++ b/examples/SBF_in_SPARTN_Test/SBF_in_SPARTN_Test.ino
@@ -149,7 +149,7 @@ void setup()
     if (!parse1)
         reportFatalError("Failed to initialize parser 1");
 
-    sempEnableDebugOutput(parse1); // Debug - comment if desired
+    sempDebugOutputEnable(parse1); // Debug - comment if desired
 
     // Add the callback for invalid SBF data,
     // to allow it to be passed to the SPARTN parser
@@ -170,7 +170,7 @@ void setup()
     if (!parse2)
         reportFatalError("Failed to initialize parser 2");
 
-    sempEnableDebugOutput(parse2); // Debug - comment if desired
+    sempDebugOutputEnable(parse2); // Debug - comment if desired
 
     // Obtain a raw data stream from somewhere
     sempPrintString(output, "Raw data stream: ");

--- a/examples/SBF_in_SPARTN_Test/SBF_in_SPARTN_Test.ino
+++ b/examples/SBF_in_SPARTN_Test/SBF_in_SPARTN_Test.ino
@@ -17,6 +17,7 @@
 
 #include <SparkFun_Extensible_Message_Parser.h> //http://librarymanager/All#SparkFun_Extensible_Message_Parser
 
+#include "../Common/output.ino"
 #include "../Common/dumpBuffer.ino"
 #include "../Common/reportFatalError.ino"
 
@@ -129,21 +130,22 @@ void setup()
     delay(1000);
 
     Serial.begin(115200);
-    Serial.println();
-    Serial.println("SBF_in_SPARTN_Test example sketch");
-    Serial.println();
+    sempPrintLn(output);
+    sempPrintStringLn(output, "SBF_in_SPARTN_Test example sketch");
+    sempPrintLn(output);
 
     // Verify the buffer size
     bufferLength = sempGetBufferLength(parserTable1, parserCount1);
     if (sizeof(buffer1) < bufferLength)
     {
-        Serial.printf("Set buffer1 size to >= %d\r\n", bufferLength);
+        sempPrintString(output, "Set buffer1 size to >= ");
+        sempPrintDecimalI32Ln(output, bufferLength);
         reportFatalError("Fix the buffer1 size!");
     }
 
     // Initialize the SBF parser
     parse1 = sempBeginParser("SBF_Test", parserTable1, parserCount1,
-                             buffer1, bufferLength, processSbfMessage);
+                             buffer1, bufferLength, processSbfMessage, output);
     if (!parse1)
         reportFatalError("Failed to initialize parser 1");
 
@@ -157,20 +159,23 @@ void setup()
     bufferLength = sempGetBufferLength(parserTable2, parserCount2);
     if (sizeof(buffer2) < bufferLength)
     {
-        Serial.printf("Set buffer2 size to >= %d\r\n", bufferLength);
+        sempPrintString(output, "Set buffer2 size to >= ");
+        sempPrintDecimalI32Ln(output, bufferLength);
         reportFatalError("Fix the buffer2 size!");
     }
 
     // Initialize the SPARTN parser
     parse2 = sempBeginParser("SPARTN_Test", parserTable2, parserCount2,
-                             buffer2, bufferLength, processSpartnMessage);
+                             buffer2, bufferLength, processSpartnMessage, output);
     if (!parse2)
         reportFatalError("Failed to initialize parser 2");
 
     sempEnableDebugOutput(parse2); // Debug - comment if desired
 
     // Obtain a raw data stream from somewhere
-    Serial.printf("Raw data stream: %d bytes\r\n", RAW_DATA_BYTES);
+    sempPrintString(output, "Raw data stream: ");
+    sempPrintDecimalI32(output, RAW_DATA_BYTES);
+    sempPrintStringLn(output, " bytes");
 
     // The raw data stream is passed to the SBF parser one byte at a time
     // Any data which is not SBF is passed to the SPARTN parser via the callback
@@ -184,7 +189,7 @@ void setup()
     // Done parsing the data
     sempStopParser(&parse1);
     sempStopParser(&parse2);
-    Serial.printf("All done\r\n");
+    sempPrintStringLn(output, "All done");
 }
 
 //----------------------------------------
@@ -214,23 +219,29 @@ void processSbfMessage(SEMP_PARSE_STATE *parse, uint16_t type)
     uint32_t offset;
 
     // Display the raw message
-    Serial.println();
+    sempPrintLn(output);
     offset = dataOffset1 + 1 - parse->length;
-    Serial.printf("Valid SBF message block %d : %d bytes at 0x%08lx (%ld)\r\n",
-                  sempSbfGetId(parse),
-                  parse->length, offset, offset);
+    sempPrintString(output, "Valid SBF message block ");
+    sempPrintDecimalI32(output, sempSbfGetId(parse));
+    sempPrintString(output, " : ");
+    sempPrintDecimalI32(output, parse->length);
+    sempPrintString(output, " bytes at ");
+    sempPrintHex0x08x(output, offset);
+    sempPrintString(output, " (");
+    sempPrintDecimalI32(output, offset);
+    sempPrintCharLn(output, ')');
     dumpBuffer(parse->buffer, parse->length);
 
     // Display Block Number
-    Serial.print("SBF Block Number: ");
-    Serial.println(sempSbfGetBlockNumber(parse));
+    sempPrintString(output, "SBF Block Number: ");
+    sempPrintDecimalI32Ln(output, sempSbfGetBlockNumber(parse));
 
     // Display the parser state
     static bool displayOnce = true;
     if (displayOnce)
     {
         displayOnce = false;
-        Serial.println();
+        sempPrintLn(output);
         sempPrintParserConfiguration(parse, &Serial);
     }
 }
@@ -244,18 +255,21 @@ void processSpartnMessage(SEMP_PARSE_STATE *parse, uint16_t type)
     static bool displayOnce = true;
 
     // Display the raw message
-    Serial.println();
-    Serial.printf("Valid SPARTN message, type %d, subtype %d : %d bytes\r\n",
-                  sempSpartnGetMessageType(parse),
-                  sempSpartnGetMessageSubType(parse),
-                  parse->length);
+    sempPrintLn(output);
+    sempPrintString(output, "Valid SPARTN message, type ");
+    sempPrintDecimalI32(output, sempSpartnGetMessageType(parse));
+    sempPrintString(output, ", subtype ");
+    sempPrintDecimalI32(output, sempSpartnGetMessageSubType(parse));
+    sempPrintString(output, " : ");
+    sempPrintDecimalI32(output, parse->length);
+    sempPrintStringLn(output, " bytes");
     dumpBuffer(parse->buffer, parse->length);
 
     // Display the parser state
     if (displayOnce)
     {
         displayOnce = false;
-        Serial.println();
+        sempPrintLn(output);
         sempPrintParserConfiguration(parse, &Serial);
     }
 }

--- a/examples/SBF_in_SPARTN_Test/SBF_in_SPARTN_Test.ino
+++ b/examples/SBF_in_SPARTN_Test/SBF_in_SPARTN_Test.ino
@@ -242,7 +242,7 @@ void processSbfMessage(SEMP_PARSE_STATE *parse, uint16_t type)
     {
         displayOnce = false;
         sempPrintLn(output);
-        sempPrintParserConfiguration(parse, &Serial);
+        sempPrintParserConfiguration(parse, output);
     }
 }
 
@@ -270,6 +270,6 @@ void processSpartnMessage(SEMP_PARSE_STATE *parse, uint16_t type)
     {
         displayOnce = false;
         sempPrintLn(output);
-        sempPrintParserConfiguration(parse, &Serial);
+        sempPrintParserConfiguration(parse, output);
     }
 }

--- a/examples/SPARTN_Test/SPARTN_Test.ino
+++ b/examples/SPARTN_Test/SPARTN_Test.ino
@@ -229,6 +229,6 @@ void processMessage(SEMP_PARSE_STATE *parse, uint16_t type)
     {
         displayOnce = false;
         sempPrintLn(output);
-        sempPrintParserConfiguration(parse, &Serial);
+        sempPrintParserConfiguration(parse, output);
     }
 }

--- a/examples/SPARTN_Test/SPARTN_Test.ino
+++ b/examples/SPARTN_Test/SPARTN_Test.ino
@@ -170,7 +170,7 @@ void setup()
     sempPrintStringLn(output, " bytes");
 
     // The raw data stream is passed to the parser one byte at a time
-    sempEnableDebugOutput(parse);
+    sempDebugOutputEnable(parse);
     for (dataOffset = 0; dataOffset < RAW_DATA_BYTES; dataOffset++)
         // Update the parser state based on the incoming byte
         sempParseNextByte(parse, rawDataStream[dataOffset]);

--- a/examples/UBLOX_Test/UBLOX_Test.ino
+++ b/examples/UBLOX_Test/UBLOX_Test.ino
@@ -205,7 +205,7 @@ void processMessage(SEMP_PARSE_STATE *parse, uint16_t type)
     {
         displayOnce = false;
         sempPrintLn(output);
-        sempPrintParserConfiguration(parse, &Serial);
+        sempPrintParserConfiguration(parse, output);
     }
 
     // Test UBX data parse routines

--- a/examples/UBLOX_Test/UBLOX_Test.ino
+++ b/examples/UBLOX_Test/UBLOX_Test.ino
@@ -8,6 +8,7 @@
 
 #include <SparkFun_Extensible_Message_Parser.h> //http://librarymanager/All#SparkFun_Extensible_Message_Parser
 
+#include "../Common/output.ino"
 #include "../Common/dumpBuffer.ino"
 #include "../Common/reportFatalError.ino"
 
@@ -136,26 +137,29 @@ void setup()
     delay(1000);
 
     Serial.begin(115200);
-    Serial.println();
-    Serial.println("UBLOX_Test example sketch");
-    Serial.println();
+    sempPrintLn(output);
+    sempPrintStringLn(output, "UBLOX_Test example sketch");
+    sempPrintLn(output);
 
     // Verify the buffer size
     bufferLength = sempGetBufferLength(parserTable, parserCount);
     if (sizeof(buffer) < bufferLength)
     {
-        Serial.printf("Set buffer size to >= %d\r\n", bufferLength);
+        sempPrintString(output, "Set buffer size to >= ");
+        sempPrintDecimalI32Ln(output, bufferLength);
         reportFatalError("Fix the buffer size!");
     }
 
     // Initialize the parser
     parse = sempBeginParser("UBLOX_Test", parserTable, parserCount,
-                            buffer, bufferLength, processMessage);
+                            buffer, bufferLength, processMessage, output);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 
     // Obtain a raw data stream from somewhere
-    Serial.printf("Raw data stream: %d bytes\r\n", RAW_DATA_BYTES);
+    sempPrintString(output, "Raw data stream: ");
+    sempPrintDecimalI32(output, RAW_DATA_BYTES);
+    sempPrintStringLn(output, " bytes");
 
     // The raw data stream is passed to the parser one byte at a time
     sempEnableDebugOutput(parse);
@@ -165,7 +169,7 @@ void setup()
 
     // Done parsing the data
     sempStopParser(&parse);
-    Serial.printf("All done\r\n");
+    sempPrintStringLn(output, "All done");
 }
 
 //----------------------------------------
@@ -185,17 +189,22 @@ void processMessage(SEMP_PARSE_STATE *parse, uint16_t type)
     uint32_t offset;
 
     // Display the raw message
-    Serial.println();
+    sempPrintLn(output);
     offset = dataOffset + 1 - parse->length;
-    Serial.printf("Valid u-blox message: %d bytes at 0x%08x (%d)\r\n",
-                  parse->length, offset, offset);
+    sempPrintString(output, "Valid u-blox message: ");
+    sempPrintDecimalI32(output, parse->length);
+    sempPrintString(output, " bytes at ");
+    sempPrintHex0x08x(output, offset);
+    sempPrintString(output, " (");
+    sempPrintDecimalI32(output, offset);
+    sempPrintCharLn(output, ')');
     dumpBuffer(parse->buffer, parse->length);
 
     // Display the parser state
     if (displayOnce)
     {
         displayOnce = false;
-        Serial.println();
+        sempPrintLn(output);
         sempPrintParserConfiguration(parse, &Serial);
     }
 
@@ -203,13 +212,20 @@ void processMessage(SEMP_PARSE_STATE *parse, uint16_t type)
     if (sempUbloxGetMessageClass(parse) == 0x01) // Class: NAV
         if (sempUbloxGetMessageId(parse) == 0x07) // ID: PVT
     {
-        Serial.println("UBX-NAV-PVT:");
-        Serial.printf("Payload Length: %d\r\n", sempUbloxGetPayloadLength(parse));
-        Serial.printf("iTOW:  %ld\r\n", sempUbloxGetU4(parse, 0));
-        Serial.printf("Year:  %d\r\n", sempUbloxGetU2(parse, 4));
-        Serial.printf("Month: %d\r\n", sempUbloxGetU1(parse, 6));
-        Serial.printf("Day:   %d\r\n", sempUbloxGetU1(parse, 7));
-        Serial.printf("Latitude: %ld\r\n", sempUbloxGetI4(parse, 28));
-        Serial.printf("Longitude: %ld\r\n", sempUbloxGetI4(parse, 24));
+        sempPrintStringLn(output, "UBX-NAV-PVT:");
+        sempPrintString(output, "Payload Length: ");
+        sempPrintDecimalI32Ln(output, sempUbloxGetPayloadLength(parse));
+        sempPrintString(output, "iTOW:  ");
+        sempPrintDecimalI32Ln(output, sempUbloxGetU4(parse, 0));
+        sempPrintString(output, "Year:  ");
+        sempPrintDecimalI32Ln(output, sempUbloxGetU2(parse, 4));
+        sempPrintString(output, "Month: ");
+        sempPrintDecimalI32Ln(output, sempUbloxGetU1(parse, 6));
+        sempPrintString(output, "Day:   ");
+        sempPrintDecimalI32Ln(output, sempUbloxGetU1(parse, 7));
+        sempPrintString(output, "Latitude: ");
+        sempPrintDecimalI32Ln(output, sempUbloxGetI4(parse, 28));
+        sempPrintString(output, "Longitude: ");
+        sempPrintDecimalI32Ln(output, sempUbloxGetI4(parse, 24));
     }
 }

--- a/examples/UBLOX_Test/UBLOX_Test.ino
+++ b/examples/UBLOX_Test/UBLOX_Test.ino
@@ -162,7 +162,7 @@ void setup()
     sempPrintStringLn(output, " bytes");
 
     // The raw data stream is passed to the parser one byte at a time
-    sempEnableDebugOutput(parse);
+    sempDebugOutputEnable(parse);
     for (dataOffset = 0; dataOffset < RAW_DATA_BYTES; dataOffset++)
         // Update the parser state based on the incoming byte
         sempParseNextByte(parse, rawDataStream[dataOffset]);

--- a/examples/Unicore_Binary_Test/Unicore_Binary_Test.ino
+++ b/examples/Unicore_Binary_Test/Unicore_Binary_Test.ino
@@ -8,6 +8,7 @@
 
 #include <SparkFun_Extensible_Message_Parser.h> //http://librarymanager/All#SparkFun_Extensible_Message_Parser
 
+#include "../Common/output.ino"
 #include "../Common/dumpBuffer.ino"
 #include "../Common/reportFatalError.ino"
 
@@ -133,26 +134,29 @@ void setup()
     delay(1000);
 
     Serial.begin(115200);
-    Serial.println();
-    Serial.println("Unicore_Test example sketch");
-    Serial.println();
+    sempPrintLn(output);
+    sempPrintStringLn(output, "Unicore_Test example sketch");
+    sempPrintLn(output);
 
     // Verify the buffer size
     bufferLength = sempGetBufferLength(parserTable, parserCount);
     if (sizeof(buffer) < bufferLength)
     {
-        Serial.printf("Set buffer size to >= %d\r\n", bufferLength);
+        sempPrintString(output, "Set buffer size to >= ");
+        sempPrintDecimalI32Ln(output, bufferLength);
         reportFatalError("Fix the buffer size!");
     }
 
     // Initialize the parser
     parse = sempBeginParser("Unicore_Test", parserTable, parserCount,
-                            buffer, bufferLength, processMessage);
+                            buffer, bufferLength, processMessage, output);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 
     // Obtain a raw data stream from somewhere
-    Serial.printf("Raw data stream: %d bytes\r\n", RAW_DATA_BYTES);
+    sempPrintString(output, "Raw data stream: ");
+    sempPrintDecimalI32(output, RAW_DATA_BYTES);
+    sempPrintStringLn(output, " bytes");
 
     // The raw data stream is passed to the parser one byte at a time
     sempEnableDebugOutput(parse);
@@ -162,7 +166,7 @@ void setup()
 
     // Done parsing the data
     sempStopParser(&parse);
-    Serial.printf("All done\r\n");
+    sempPrintStringLn(output, "All done");
 }
 
 //----------------------------------------
@@ -182,17 +186,24 @@ void processMessage(SEMP_PARSE_STATE *parse, uint16_t type)
     uint32_t offset;
 
     // Display the raw message
-    Serial.println();
+    sempPrintLn(output);
     offset = dataOffset + 1 - parse->length;
-    Serial.printf("Valid Unicore message: 0x%04x (%d) bytes at 0x%08x (%d)\r\n",
-                  parse->length, parse->length, offset, offset);
+    sempPrintString(output, "Valid Unicore message: ");
+    sempPrintHex0x04x(output, parse->length);
+    sempPrintString(output, " (");
+    sempPrintDecimalI32(output, parse->length);
+    sempPrintString(output, ") bytes at ");
+    sempPrintHex0x08x(output, offset);
+    sempPrintString(output, " (");
+    sempPrintDecimalI32(output, offset);
+    sempPrintCharLn(output, ')');
     dumpBuffer(parse->buffer, parse->length);
 
     // Display the parser state
     if (displayOnce)
     {
         displayOnce = false;
-        Serial.println();
+        sempPrintLn(output);
         sempPrintParserConfiguration(parse, &Serial);
     }
 }

--- a/examples/Unicore_Binary_Test/Unicore_Binary_Test.ino
+++ b/examples/Unicore_Binary_Test/Unicore_Binary_Test.ino
@@ -159,7 +159,7 @@ void setup()
     sempPrintStringLn(output, " bytes");
 
     // The raw data stream is passed to the parser one byte at a time
-    sempEnableDebugOutput(parse);
+    sempDebugOutputEnable(parse);
     for (dataOffset = 0; dataOffset < RAW_DATA_BYTES; dataOffset++)
         // Update the parser state based on the incoming byte
         sempParseNextByte(parse, rawDataStream[dataOffset]);

--- a/examples/Unicore_Binary_Test/Unicore_Binary_Test.ino
+++ b/examples/Unicore_Binary_Test/Unicore_Binary_Test.ino
@@ -204,6 +204,6 @@ void processMessage(SEMP_PARSE_STATE *parse, uint16_t type)
     {
         displayOnce = false;
         sempPrintLn(output);
-        sempPrintParserConfiguration(parse, &Serial);
+        sempPrintParserConfiguration(parse, output);
     }
 }

--- a/examples/Unicore_Hash_Test/Unicore_Hash_Test.ino
+++ b/examples/Unicore_Hash_Test/Unicore_Hash_Test.ino
@@ -106,7 +106,7 @@ void setup()
     // Initialize the parser
     parse = sempBeginParser("Unicore_Hash_Test", parserTable, parserCount,
                             buffer, bufferLength, processMessage,
-                            &Serial, nullptr, badUnicoreHashChecksum);
+                            nullptr, &Serial, nullptr, badUnicoreHashChecksum);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 

--- a/examples/Unicore_Hash_Test/Unicore_Hash_Test.ino
+++ b/examples/Unicore_Hash_Test/Unicore_Hash_Test.ino
@@ -108,7 +108,7 @@ void setup()
     // Initialize the parser
     parse = sempBeginParser("Unicore_Hash_Test", parserTable, parserCount,
                             buffer, bufferLength, processMessage, output,
-                            &Serial, nullptr, badUnicoreHashChecksum);
+                            &Serial, badUnicoreHashChecksum);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 
@@ -118,7 +118,7 @@ void setup()
     sempPrintStringLn(output, " bytes");
 
     // The raw data stream is passed to the parser one byte at a time
-    sempEnableDebugOutput(parse);
+    sempDebugOutputEnable(parse);
     for (dataOffset = 0; dataOffset < RAW_DATA_BYTES; dataOffset++)
         // Update the parser state based on the incoming byte
         sempParseNextByte(parse, rawDataStream[dataOffset]);

--- a/examples/User_Parser_Test/User_Parser.cpp
+++ b/examples/User_Parser_Test/User_Parser.cpp
@@ -56,10 +56,14 @@ bool userSecondPreambleByte(SEMP_PARSE_STATE *parse, uint8_t data)
     // Validate the second preamble byte
     if (data != 'B')
     {
+        SEMP_OUTPUT output = parse->debugOutput;
+
         // Print the error
-        sempPrintf(parse->printDebug,
-                   "USER_Parser: Bad second preamble byte after message %d",
-                   scratchPad->messageNumber);
+        if (output)
+        {
+            sempPrintString(output, "USER_Parser: Bad second preamble byte after message ");
+            sempPrintDecimalI32Ln(output, scratchPad->messageNumber);
+        }
 
         // Start searching for a preamble byte
         return sempFirstByte(parse, data);

--- a/examples/User_Parser_Test/User_Parser_Test.ino
+++ b/examples/User_Parser_Test/User_Parser_Test.ino
@@ -98,7 +98,7 @@ void setup()
     sempPrintStringLn(output, " bytes");
 
     // The raw data stream is passed to the parser one byte at a time
-    sempEnableDebugOutput(parse);
+    sempDebugOutputEnable(parse);
     for (dataOffset = 0; dataOffset < RAW_DATA_BYTES; dataOffset++)
     {
         uint8_t data;

--- a/examples/User_Parser_Test/User_Parser_Test.ino
+++ b/examples/User_Parser_Test/User_Parser_Test.ino
@@ -169,6 +169,6 @@ void userMessage(SEMP_PARSE_STATE *parse, uint16_t type)
     {
         displayOnce = false;
         sempPrintLn(output);
-        sempPrintParserConfiguration(parse, &Serial);
+        sempPrintParserConfiguration(parse, output);
     }
 }

--- a/src/Parse_SPARTN.cpp
+++ b/src/Parse_SPARTN.cpp
@@ -110,12 +110,23 @@ bool sempSpartnReadTF018(SEMP_PARSE_STATE *parse, uint8_t data)
         if (valid)
             parse->eomCallback(parse, parse->type); // Pass parser array index
         else
-            sempPrintf(parse->printDebug,
-                    "SEMP %s: SPARTN %d %d, 0x%04x (%d) bytes, bad CRC",
-                    parse->parserName,
-                    scratchPad->messageType,
-                    scratchPad->messageSubtype,
-                    parse->length, parse->length);
+        {
+            SEMP_OUTPUT output = parse->debugOutput;
+            if (output)
+            {
+                sempPrintString(output, "SEMP ");
+                sempPrintString(output, parse->parserName);
+                sempPrintString(output, ": SPARTN ");
+                sempPrintDecimalI32(output, scratchPad->messageType);
+                output(' ');
+                sempPrintDecimalI32(output, scratchPad->messageSubtype);
+                sempPrintString(output, ", ");
+                sempPrintHex0x04x(output, parse->length);
+                sempPrintString(output, " (");
+                sempPrintDecimalI32(output, parse->length);
+                sempPrintStringLn(output, ") bytes, bad CRC");
+            }
+        }
         parse->state = sempFirstByte;
         return false;
     }
@@ -236,6 +247,7 @@ bool sempSpartnReadTF007(SEMP_PARSE_STATE *parse, uint8_t data)
 //----------------------------------------
 bool sempSpartnReadTF002TF006(SEMP_PARSE_STATE *parse, uint8_t data)
 {
+    SEMP_OUTPUT output = parse->debugOutput;
     SEMP_SPARTN_VALUES *scratchPad = (SEMP_SPARTN_VALUES *)parse->scratchPad;
 
     if (scratchPad->frameCount == 0)
@@ -274,13 +286,20 @@ bool sempSpartnReadTF002TF006(SEMP_PARSE_STATE *parse, uint8_t data)
         if (semp_uSpartnCrc4(&parse->buffer[1], 3) == scratchPad->frameCRC)
         {
             parse->buffer[3] = data; // Restore TF005 and TF006 now we know the data is valid
-            if (parse->verboseDebug)
-                sempPrintf(parse->printDebug,
-                        "SEMP %s: Incoming SPARTN %d %d, 0x%04x (%d) bytes",
-                        parse->parserName,
-                        scratchPad->messageType,
-                        scratchPad->messageSubtype,
-                        scratchPad->payloadLength, scratchPad->payloadLength);
+            if (parse->verboseDebug && output)
+            {
+                sempPrintString(output, "SEMP ");
+                sempPrintString(output, parse->parserName);
+                sempPrintString(output, ": Incoming SPARTN ");
+                sempPrintDecimalI32(output, scratchPad->messageType);
+                output(' ');
+                sempPrintDecimalI32(output, scratchPad->messageSubtype);
+                sempPrintString(output, ", ");
+                sempPrintHex0x04x(output, scratchPad->payloadLength);
+                sempPrintString(output, " (");
+                sempPrintDecimalI32(output, scratchPad->payloadLength);
+                sempPrintStringLn(output, ") bytes");
+            }
             parse->state = sempSpartnReadTF007;
         }
         else
@@ -288,13 +307,18 @@ bool sempSpartnReadTF002TF006(SEMP_PARSE_STATE *parse, uint8_t data)
             // Invalid header CRC
             parse->buffer[3] = data; // Restore the byte now we know the data is invalid
             parse->state = sempFirstByte;
-
-            sempPrintf(parse->printDebug,
-                    "SEMP %s: SPARTN %d, 0x%04x (%d) bytes, bad header CRC",
-                    parse->parserName,
-                    scratchPad->messageType,
-                    parse->length, parse->length);
-
+            if (output)
+            {
+                sempPrintString(output, "SEMP ");
+                sempPrintString(output, parse->parserName);
+                sempPrintString(output, ": SPARTN ");
+                sempPrintDecimalI32(output, scratchPad->messageType);
+                sempPrintString(output, ", ");
+                sempPrintHex0x04x(output, parse->length);
+                sempPrintString(output, " (");
+                sempPrintDecimalI32(output, parse->length);
+                sempPrintStringLn(output, ") bytes, bad header CRC");
+            }
             return false;
         }
     }

--- a/src/SparkFun_Extensible_Message_Parser.cpp
+++ b/src/SparkFun_Extensible_Message_Parser.cpp
@@ -181,7 +181,7 @@ SEMP_PARSE_STATE *sempBeginParser(
         parse->type = parserCount;  // No active parser
 
         // Display the parser configuration
-        sempPrintParserConfiguration(parse, parse->printDebug);
+        sempPrintParserConfiguration(parse, parse->debugOutput);
     } while (0);
 
     // Return the parse structure address
@@ -1148,32 +1148,80 @@ void sempPrintLn(SEMP_OUTPUT output)
 //----------------------------------------
 // Print the parser's configuration
 //----------------------------------------
-void sempPrintParserConfiguration(SEMP_PARSE_STATE *parse, Print *print)
+void sempPrintParserConfiguration(SEMP_PARSE_STATE *parse, SEMP_OUTPUT output)
 {
-    if (print && parse)
+    if (output && parse)
     {
-        sempPrintln(print, "SparkFun Extensible Message Parser");
-        sempPrintf(print, "    parserName: %p (%s)", parse->parserName, parse->parserName);
-        sempPrintf(print, "    parsers: %p", (void *)parse->parsers);
-        sempPrintf(print, "    parserCount: %d", parse->parserCount);
-        sempPrintf(print, "    printError: %p", parse->printError);
-        sempPrintf(print, "    printDebug: %p", parse->printDebug);
-        sempPrintf(print, "    verboseDebug: %d", parse->verboseDebug);
-        sempPrintf(print, "    nmeaAbortOnNonPrintable: %d", parse->nmeaAbortOnNonPrintable);
-        sempPrintf(print, "    unicoreHashAbortOnNonPrintable: %d", parse->unicoreHashAbortOnNonPrintable);
-        sempPrintf(print, "    Scratch Pad: %p (%ld bytes)",
-                   (void *)parse->scratchPad,
-                   parse->scratchPad ? (parse->buffer - (uint8_t *)parse->scratchPad)
-                                     : 0);
-        sempPrintf(print, "    computeCrc: %p", (void *)parse->computeCrc);
-        sempPrintf(print, "    crc: 0x%08x", parse->crc);
-        sempPrintf(print, "    State: %p%s", (void *)parse->state,
-                   (parse->state == sempFirstByte) ? " (sempFirstByte)" : "");
-        sempPrintf(print, "    EomCallback: %p", (void *)parse->eomCallback);
-        sempPrintf(print, "    Buffer: %p (%d bytes)",
-                   (void *)parse->buffer, parse->bufferLength);
-        sempPrintf(print, "    length: %d message bytes", parse->length);
-        sempPrintf(print, "    type: %d (%s)", parse->type, sempGetTypeName(parse, parse->type));
+        sempPrintString(output, "SparkFun Extensible Message Parser\r\n");
+
+        sempPrintString(output, "    parserName: ");
+        sempPrintAddr(output, (void *)parse->parserName);
+        sempPrintString(output, " (");
+        sempPrintString(output, parse->parserName);
+        sempPrintCharLn(output, ')');
+
+        sempPrintString(output, "    parsers: ");
+        sempPrintAddrLn(output, (void *)parse->parsers);
+
+        sempPrintString(output, "    parserCount: ");
+        sempPrintDecimalI32Ln(output, parse->parserCount);
+
+        sempPrintString(output, "    debugOutput: ");
+        sempPrintAddrLn(output, (void *)parse->debugOutput);
+
+        sempPrintString(output, "    printError: ");
+        sempPrintAddrLn(output, (void *)parse->printError);
+
+        sempPrintString(output, "    verboseDebug: ");
+        sempPrintDecimalI32Ln(output, parse->verboseDebug);
+
+        sempPrintString(output, "    nmeaAbortOnNonPrintable: ");
+        sempPrintDecimalI32Ln(output, parse->nmeaAbortOnNonPrintable);
+
+        sempPrintString(output, "    unicoreHashAbortOnNonPrintable: ");
+        sempPrintDecimalI32Ln(output, parse->unicoreHashAbortOnNonPrintable);
+
+        sempPrintString(output, "    scratchPad: ");
+        sempPrintAddr(output, (void *)parse->scratchPad);
+        sempPrintString(output, " (");
+        if (parse->scratchPad)
+            sempPrintDecimalI32(output, parse->buffer - (uint8_t *)parse->scratchPad);
+        else
+            output('0');
+        sempPrintStringLn(output, " bytes)");
+
+        sempPrintString(output, "    computeCrc: ");
+        sempPrintAddrLn(output, (void *)parse->computeCrc);
+
+        sempPrintString(output, "    crc: 0x");
+        sempPrintHex08xLn(output, parse->crc);
+
+        sempPrintString(output, "    state: ");
+        sempPrintAddr(output, (void *)parse->state);
+        sempPrintStringLn(output, (parse->state == sempFirstByte) ? " (sempFirstByte)"
+                                                                  : "");
+
+        sempPrintString(output, "    eomCallback: ");
+        sempPrintAddrLn(output, (void *)parse->eomCallback);
+
+        sempPrintString(output, "    invalidData: ");
+        sempPrintAddrLn(output, (void *)parse->invalidData);
+
+        sempPrintString(output, "    buffer: ");
+        sempPrintAddr(output, (void *)parse->buffer);
+        sempPrintString(output, " (");
+        sempPrintDecimalI32(output, parse->bufferLength);
+        sempPrintStringLn(output, " bytes)");
+
+        sempPrintString(output, "    length: ");
+        sempPrintDecimalI32(output, parse->length);
+        sempPrintStringLn(output, " message bytes");
+
+        sempPrintString(output, "    type: ");
+        sempPrintDecimalI32(output, parse->type);
+        sempPrintString(output, " (");
+        sempPrintString(output, sempGetTypeName(parse, parse->type));
+        sempPrintCharLn(output, ')');
     }
 }
 

--- a/src/SparkFun_Extensible_Message_Parser.cpp
+++ b/src/SparkFun_Extensible_Message_Parser.cpp
@@ -81,6 +81,7 @@ SEMP_PARSE_STATE *sempBeginParser(
     uint8_t * buffer,
     size_t bufferLength,
     SEMP_EOM_CALLBACK eomCallback,
+    SEMP_OUTPUT debugOutput,
     Print *printError,
     Print *printDebug,
     SEMP_BAD_CRC_CALLBACK badCrc
@@ -169,6 +170,7 @@ SEMP_PARSE_STATE *sempBeginParser(
         parse->bufferLength = bufferLength - bufferOverhead;
 
         // Initialize the parse state
+        parse->debugOutput = debugOutput;
         parse->printError = printError;
         parse->parsers = parserTable;
         parse->parserCount = parserCount;
@@ -245,7 +247,10 @@ size_t sempComputeBufferOverhead(SEMP_PARSER_DESCRIPTION **parserTable,
 void sempDisableDebugOutput(SEMP_PARSE_STATE *parse)
 {
     if (parse)
+    {
+        parse->debugOutput = nullptr;
         parse->printDebug = nullptr;
+    }
 }
 
 //----------------------------------------

--- a/src/SparkFun_Extensible_Message_Parser.h
+++ b/src/SparkFun_Extensible_Message_Parser.h
@@ -130,7 +130,6 @@ typedef struct _SEMP_PARSE_STATE
     const char *parserName;        // Name of parser table
     void *scratchPad;              // Parser scratchpad area
     Print *printError;             // Class to use for error output
-    Print *printDebug;             // Class to use for debug output
     SEMP_OUTPUT debugOutput;       // Output a debug character
     bool verboseDebug;             // Verbose debug output (default: false)
     uint32_t crc;                  // RTCM computed CRC
@@ -187,7 +186,6 @@ typedef struct _SEMP_UNICORE_HEADER
 //   oemCallback: Address of a callback routine to handle the parsed messages
 //   debugOutput: Addess of a routine to output a debug character, myabe nullptr
 //   printError: Addess of a routine used to output error messages
-//   printDebug: Addess of a routine used to output debug messages
 //   badCrcCallback: Address of a routine to handle bad CRC messages
 //
 // Outputs:
@@ -239,20 +237,29 @@ SEMP_PARSE_STATE * sempBeginParser(const char *parserTableName,
                                    SEMP_EOM_CALLBACK eomCallback,
                                    SEMP_OUTPUT debugOutput = nullptr,
                                    Print *printError = &Serial,
-                                   Print *printDebug = (Print *)nullptr,
                                    SEMP_BAD_CRC_CALLBACK badCrcCallback = (SEMP_BAD_CRC_CALLBACK)nullptr);
 
 // Disable debug output
 //
 // Inputs:
 //   parse: Address of a SEMP_PARSE_STATE structure
-void sempDisableDebugOutput(SEMP_PARSE_STATE *parse);
+void sempDebugOutputDisable(SEMP_PARSE_STATE *parse);
+
+// Enable debug output
+//
+// Inputs:
+//   parse: Address of a SEMP_PARSE_STATE structure
+//   output: Address of a SEMP_OUTPUT routine to use for output
+//   verbose: Enable or disable verbose debug output
+void sempDebugOutputEnable(SEMP_PARSE_STATE *parse,
+                           SEMP_OUTPUT output = nullptr,
+                           bool verbose = false);
 
 // Disable error output
 //
 // Inputs:
 //   parse: Address of a SEMP_PARSE_STATE structure
-void sempDisableErrorOutput(SEMP_PARSE_STATE *parse);
+void sempErrorOutputDisable(SEMP_PARSE_STATE *parse);
 
 // Compute the necessary buffer length in bytes to support the scratch pad
 // and parse buffer lengths.
@@ -261,7 +268,7 @@ void sempDisableErrorOutput(SEMP_PARSE_STATE *parse);
 //   parseTable: Address of an array of SEMP_PARSER_DESCRIPTION addresses
 //   parserCount:  Number of entries in the parseTable
 //   desiredParseAreaSize: Desired size of the parse area in bytes
-//   printDebug: Device to output any debug messages, may be nullptr
+//   output: Device to output any debug messages, may be nullptr
 //
 // Outputs:
 //    Returns the number of bytes needed for the buffer that contains
@@ -269,7 +276,7 @@ void sempDisableErrorOutput(SEMP_PARSE_STATE *parse);
 size_t sempGetBufferLength(SEMP_PARSER_DESCRIPTION **parserTable,
                            uint16_t parserCount,
                            size_t desiredParseAreaSize = 0,
-                           Print *printDebug = &Serial);
+                           SEMP_OUTPUT output = nullptr);
 
 // Translates state value into an ASCII state name
 //
@@ -1002,15 +1009,6 @@ const char * sempUnicoreHashGetSentenceName(const SEMP_PARSE_STATE *parse);
 //------------------------------------------------------------------------------
 // V1 routines to be eliminated
 //------------------------------------------------------------------------------
-
-// Enable debug output
-//
-// Inputs:
-//   parse: Address of a SEMP_PARSE_STATE structure
-//   print: Address of a Print object to use for output
-void sempEnableDebugOutput(SEMP_PARSE_STATE *parse,
-                           Print *print = &Serial,
-                           bool verbose = false);
 
 // Enable error output
 //

--- a/src/SparkFun_Extensible_Message_Parser.h
+++ b/src/SparkFun_Extensible_Message_Parser.h
@@ -792,8 +792,9 @@ void sempPrintLn(SEMP_OUTPUT output);
 //
 // Inputs:
 //   parse: Address of a SEMP_PARSE_STATE structure
-//   print: Address of a Print object to use for output
-void sempPrintParserConfiguration(SEMP_PARSE_STATE *parse, Print *print = &Serial);
+//   output: Addess of a routine to output a debug character
+void sempPrintParserConfiguration(SEMP_PARSE_STATE *parse,
+                                  SEMP_OUTPUT output = nullptr);
 
 // Display a string
 //

--- a/src/SparkFun_Extensible_Message_Parser.h
+++ b/src/SparkFun_Extensible_Message_Parser.h
@@ -131,6 +131,7 @@ typedef struct _SEMP_PARSE_STATE
     void *scratchPad;              // Parser scratchpad area
     Print *printError;             // Class to use for error output
     Print *printDebug;             // Class to use for debug output
+    SEMP_OUTPUT debugOutput;       // Output a debug character
     bool verboseDebug;             // Verbose debug output (default: false)
     uint32_t crc;                  // RTCM computed CRC
     uint8_t *buffer;               // Buffer containing the message
@@ -183,7 +184,8 @@ typedef struct _SEMP_UNICORE_HEADER
 //   parserCount:  Number of entries in the parseTable
 //   buffer: Address of the buffer to be used for parser state, scratchpad
 //   bufferLength: Number of bytes in the buffer
-//   oemCallback: Address of a callback routine to handle the output
+//   oemCallback: Address of a callback routine to handle the parsed messages
+//   debugOutput: Addess of a routine to output a debug character, myabe nullptr
 //   printError: Addess of a routine used to output error messages
 //   printDebug: Addess of a routine used to output debug messages
 //   badCrcCallback: Address of a routine to handle bad CRC messages
@@ -235,6 +237,7 @@ SEMP_PARSE_STATE * sempBeginParser(const char *parserTableName,
                                    uint8_t * buffer,
                                    size_t bufferLength,
                                    SEMP_EOM_CALLBACK eomCallback,
+                                   SEMP_OUTPUT debugOutput = nullptr,
                                    Print *printError = &Serial,
                                    Print *printDebug = (Print *)nullptr,
                                    SEMP_BAD_CRC_CALLBACK badCrcCallback = (SEMP_BAD_CRC_CALLBACK)nullptr);

--- a/src/SparkFun_Extensible_Message_Parser.h
+++ b/src/SparkFun_Extensible_Message_Parser.h
@@ -89,6 +89,12 @@ typedef const char * (*SEMP_GET_STATE_NAME)(const struct _SEMP_PARSE_STATE * par
 // goes back to scanning for the first preamble byte.
 typedef void (*SEMP_INVALID_DATA_CALLBACK)(const uint8_t * buffer, size_t length);
 
+// Call the application to output a single character
+//
+// Inputs:
+//   data: Data byte to output
+typedef void (*SEMP_OUTPUT)(char data);
+
 // Parse routine
 //
 // Inputs:
@@ -567,12 +573,238 @@ void sempInvalidDataCallback(SEMP_PARSE_STATE *parse);
 //   or -1 upon failure for invalid characters
 int sempAsciiToNibble(int data);
 
+// Convert nibble to ASCII
+//
+// Inputs:
+//   nibble: Binary value, the low 4 bits will be converted into ASCII
+//
+// Outputs:
+//   Returns an ASCII character representing the lower 4 bits of the input
+//   value (0-9, a-f)
+char sempNibbleToAscii(int nibble);
+
+// Display an address value
+//
+// Inputs:
+//   output: Device on which to output the string
+//   addr: A binary value to display as ASCII hex characters
+void sempPrintAddr(SEMP_OUTPUT output, const void *addr);
+
+// Display an address value followed by a CR and LF
+//
+// Inputs:
+//   output: Device on which to output the string
+//   addr: A binary value to display as ASCII hex characters
+void sempPrintAddrLn(SEMP_OUTPUT output, const void *addr);
+
+// Display a character
+//
+// Inputs:
+//   output: Device on which to output the string
+//   character: The character value to output
+void sempPrintChar(SEMP_OUTPUT output, char character);
+
+// Display a character followed by a CR and LF
+//
+// Inputs:
+//   output: Device on which to output the string
+//   character: The character value to output
+void sempPrintCharLn(SEMP_OUTPUT output, char character);
+
+// Display a signed 32-bit decimal value
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintDecimalI32(SEMP_OUTPUT output, int32_t value);
+
+// Display a signed 32-bit decimal value followed by a CR and LF
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintDecimalI32Ln(SEMP_OUTPUT output, int32_t value);
+
+// Display a signed 64-bit decimal value
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintDecimalI64(SEMP_OUTPUT output, int64_t value);
+
+// Display a signed 64-bit decimal value followed by a CR and LF
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintDecimalI64Ln(SEMP_OUTPUT output, int64_t value);
+
+// Display an unsigned 32-bit decimal value
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintDecimalU32(SEMP_OUTPUT output, uint32_t value);
+
+// Display an unsigned 32-bit decimal value followed by a CR and LF
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintDecimalU32Ln(SEMP_OUTPUT output, uint32_t value);
+
+// Display an unsigned 64-bit decimal value
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintDecimalU64(SEMP_OUTPUT output, uint64_t value);
+
+// Display an unsigned 64-bit decimal value followed by a CR and LF
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintDecimalU64Ln(SEMP_OUTPUT output, uint64_t value);
+
+// Display an 8-bit hex value
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintHex02x(SEMP_OUTPUT output, uint8_t value);
+
+// Display an 8-bit hex value followed by a CR and LF
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintHex02xLn(SEMP_OUTPUT output, uint8_t value);
+
+// Display a 16-bit hex value
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintHex04x(SEMP_OUTPUT output, uint16_t value);
+
+// Display a 16-bit hex value followed by a CR and LF
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintHex04xLn(SEMP_OUTPUT output, uint16_t value);
+
+// Display a 32-bit hex value
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintHex08x(SEMP_OUTPUT output, uint32_t value);
+
+// Display a 32-bit hex value followed by a CR and LF
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintHex08xLn(SEMP_OUTPUT output, uint32_t value);
+
+// Display a 64-bit hex value
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintHex016x(SEMP_OUTPUT output, uint64_t value);
+
+// Display a 64-bit hex value followed by a CR and LF
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintHex016xLn(SEMP_OUTPUT output, uint64_t value);
+
+// Display an 8-bit hex value with a 0x prefix
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintHex0x02x(SEMP_OUTPUT output, uint8_t value);
+
+// Display an 8-bit hex value with a 0x prefix followed by a CR and LF
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintHex0x02xLn(SEMP_OUTPUT output, uint8_t value);
+
+// Display a 16-bit hex value with a 0x prefix
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintHex0x04x(SEMP_OUTPUT output, uint16_t value);
+
+// Display a 16-bit hex value with a 0x prefix followed by a CR and LF
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintHex0x04xLn(SEMP_OUTPUT output, uint16_t value);
+
+// Display a 32-bit hex value with a 0x prefix
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintHex0x08x(SEMP_OUTPUT output, uint32_t value);
+
+// Display a 32-bit hex value with a 0x prefix followed by a CR and LF
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintHex0x08xLn(SEMP_OUTPUT output, uint32_t value);
+
+// Display a 64-bit hex value with a 0x prefix
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintHex0x016x(SEMP_OUTPUT output, uint64_t value);
+
+// Display a 64-bit hex value with a 0x prefix followed by a CR and LF
+//
+// Inputs:
+//   output: Device on which to output the string
+//   value: A binary value to display as ASCII hex characters
+void sempPrintHex0x016xLn(SEMP_OUTPUT output, uint64_t value);
+
+// Display a carriage return and line feed
+//
+// Inputs:
+//   output: Device on which to output the string
+void sempPrintLn(SEMP_OUTPUT output);
+
 // Print the contents of the parser data structure
 //
 // Inputs:
 //   parse: Address of a SEMP_PARSE_STATE structure
 //   print: Address of a Print object to use for output
 void sempPrintParserConfiguration(SEMP_PARSE_STATE *parse, Print *print = &Serial);
+
+// Display a string
+//
+// Inputs:
+//   output: Device on which to output the string
+//   string: A zero terminated string of characters
+void sempPrintString(SEMP_OUTPUT output, const char * string);
+
+// Display a string followed by a CR and LF
+//
+// Inputs:
+//   output: Device on which to output the string
+//   string: A zero terminated string of characters
+void sempPrintStringLn(SEMP_OUTPUT output, const char * string);
 
 //------------------------------------------------------------------------------
 // Testing support routines - Must only be called by testing routines


### PR DESCRIPTION
This PR includes the following changes:
* Add the print support routines
* Add the debugOutput routine
* Add and use the output routine in the examples with sempPrint* routines
* Change sempPrintParserConfiguration to use debugOutput
* Replace printDebug with debugOutput, use sempPrint* routines in parsers