### PR TITLE
Finish removing use of printError and references to the Print class

### DIFF
--- a/examples/Base_Test/Base_Test.ino
+++ b/examples/Base_Test/Base_Test.ino
@@ -80,44 +80,44 @@ void setup()
     }
 
     // No name specified
-    parse = sempBeginParser(nullptr, parserTable, parserCount,
-                            buffer, bufferLength, processMessage);
+    parse = sempBeginParser(nullptr, parserTable, parserCount, buffer,
+                            bufferLength, processMessage, output);
     if (parse)
         reportFatalError("Failed to detect parserName set to nullptr (0)");
 
     // No name specified
-    parse = sempBeginParser("", parserTable, parserCount,
-                            buffer, bufferLength, processMessage);
+    parse = sempBeginParser("", parserTable, parserCount, buffer,
+                            bufferLength, processMessage, output);
     if (parse)
         reportFatalError("Failed to detect parserName set to empty string");
 
     // No parser table specified
-    parse = sempBeginParser("No parser", nullptr, parserCount,
-                            buffer, bufferLength, processMessage);
+    parse = sempBeginParser("No parser", nullptr, parserCount, buffer,
+                            bufferLength, processMessage, output);
     if (parse)
         reportFatalError("Failed to detect parserTable set to nullptr (0)");
 
     // Parser count is zero
-    parse = sempBeginParser("No parser", parserTable, 0,
-                            buffer, bufferLength, processMessage);
+    parse = sempBeginParser("No parser", parserTable, 0, buffer,
+                            bufferLength, processMessage, output);
     if (parse)
         reportFatalError("Failed because parserCount != nameTableCount");
 
     // No buffer specified
-    parse = sempBeginParser("No parser", parserTable, parserCount,
-                            nullptr, bufferLength, processMessage);
+    parse = sempBeginParser("No parser", parserTable, parserCount, nullptr,
+                            bufferLength, processMessage, output);
     if (parse)
         reportFatalError("Failed to detect buffer set to nullptr (0)");
 
     // No buffer specified
-    parse = sempBeginParser("No parser", parserTable, parserCount,
-                            buffer, 0, processMessage);
+    parse = sempBeginParser("No parser", parserTable, parserCount, buffer,
+                            0, processMessage, output);
     if (parse)
         reportFatalError("Failed to detect no buffer");
 
     // Zero length usable buffer specified
-    parse = sempBeginParser("No parser", parserTable, parserCount,
-                            buffer, bufferOverhead, processMessage);
+    parse = sempBeginParser("No parser", parserTable, parserCount, buffer,
+                            bufferOverhead, processMessage, output);
     if (parse)
         reportFatalError("Failed to detect zero length buffer");
 
@@ -127,20 +127,21 @@ void setup()
         reportFatalError("Failed to get proper minimum buffer size");
 
     // Complain about buffer too small, but allow for testing
-    parse = sempBeginParser("No parser", parserTable, parserCount,
-                            buffer, minimumBufferBytes - 1, processMessage);
+    parse = sempBeginParser("No parser", parserTable, parserCount, buffer,
+                            minimumBufferBytes - 1, processMessage, output);
     if (!parse)
         reportFatalError("Failed to complain about minimum buffer size");
 
     // No end-of-message callback specified
-    parse = sempBeginParser("No parser", parserTable, parserCount,
-                            buffer, bufferLength, nullptr);
+    parse = sempBeginParser("No parser", parserTable, parserCount, buffer,
+                            bufferLength, nullptr, output);
     if (parse)
         reportFatalError("Failed to detect eomCallback set to nullptr (0)");
 
     // Start using the entire buffer
     parse = sempBeginParser("Base Test Example", parserTable, parserCount,
-                            buffer, bufferLength, processMessage, output);
+                            buffer, bufferLength, processMessage, output,
+                            output);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
     sempPrintStringLn(output, "Parser successfully initialized");

--- a/examples/Mixed_Parser/Mixed_Parser.ino
+++ b/examples/Mixed_Parser/Mixed_Parser.ino
@@ -186,8 +186,8 @@ void setup()
     }
 
     // Initialize the parser
-    parse = sempBeginParser("Mixed_Parser", parserTable, parserCount,
-                            buffer, bufferLength, processMessage, output);
+    parse = sempBeginParser("Mixed_Parser", parserTable, parserCount, buffer,
+                            bufferLength, processMessage, output, output);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 

--- a/examples/Multiple_Parsers/Multiple_Parsers.ino
+++ b/examples/Multiple_Parsers/Multiple_Parsers.ino
@@ -184,7 +184,8 @@ void setup()
 
     // Initialize the NMEA parser
     nmeaParser = sempBeginParser("NMEA_Parser", nmeaParserTable, nmeaParserCount,
-                                 buffer1, bufferLength, nmeaSentence, output);
+                                 buffer1, bufferLength, nmeaSentence, output,
+                                 output);
     if (!nmeaParser)
         reportFatalError("Failed to initialize the NMEA parser");
 
@@ -199,7 +200,7 @@ void setup()
 
     // Initialize the U-Blox parser
     ubloxParser = sempBeginParser("U-Blox_Parser", ubloxParserTable, ubloxParserCount,
-                                  buffer2, bufferLength, ubloxMessage, output);
+                                  buffer2, bufferLength, ubloxMessage, output, output);
     if (!ubloxParser)
         reportFatalError("Failed to initialize the U-Blox parser");
 

--- a/examples/NMEA_Test/NMEA_Test.ino
+++ b/examples/NMEA_Test/NMEA_Test.ino
@@ -114,8 +114,8 @@ void setup()
     }
 
     // Initialize the parser
-    parse = sempBeginParser("NMEA_Test", parserTable, parserCount,
-                            buffer, bufferLength, processMessage, output);
+    parse = sempBeginParser("NMEA_Test", parserTable, parserCount, buffer,
+                            bufferLength, processMessage, output, output);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 

--- a/examples/RTCM_Test/RTCM_Test.ino
+++ b/examples/RTCM_Test/RTCM_Test.ino
@@ -101,8 +101,8 @@ void setup()
     }
 
     // Initialize the parser
-    parse = sempBeginParser("RTCM_Test", parserTable, parserCount,
-                            buffer, bufferLength, processMessage, output);
+    parse = sempBeginParser("RTCM_Test", parserTable, parserCount, buffer,
+                            bufferLength, processMessage, output, output);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 

--- a/examples/SBF_Test/SBF_Test.ino
+++ b/examples/SBF_Test/SBF_Test.ino
@@ -100,8 +100,8 @@ void setup()
     }
 
     // Initialize the parser
-    parse = sempBeginParser("SBF_Test", parserTable, parserCount,
-                            buffer, bufferLength, processMessage, output);
+    parse = sempBeginParser("SBF_Test", parserTable, parserCount, buffer,
+                            bufferLength, processMessage, output, output);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 

--- a/examples/SBF_in_SPARTN_Test/SBF_in_SPARTN_Test.ino
+++ b/examples/SBF_in_SPARTN_Test/SBF_in_SPARTN_Test.ino
@@ -144,8 +144,8 @@ void setup()
     }
 
     // Initialize the SBF parser
-    parse1 = sempBeginParser("SBF_Test", parserTable1, parserCount1,
-                             buffer1, bufferLength, processSbfMessage, output);
+    parse1 = sempBeginParser("SBF_Test", parserTable1, parserCount1, buffer1,
+                             bufferLength, processSbfMessage, output, output);
     if (!parse1)
         reportFatalError("Failed to initialize parser 1");
 
@@ -166,7 +166,8 @@ void setup()
 
     // Initialize the SPARTN parser
     parse2 = sempBeginParser("SPARTN_Test", parserTable2, parserCount2,
-                             buffer2, bufferLength, processSpartnMessage, output);
+                             buffer2, bufferLength, processSpartnMessage,
+                             output, output);
     if (!parse2)
         reportFatalError("Failed to initialize parser 2");
 

--- a/examples/SPARTN_Test/SPARTN_Test.ino
+++ b/examples/SPARTN_Test/SPARTN_Test.ino
@@ -159,8 +159,8 @@ void setup()
     }
 
     // Initialize the parser
-    parse = sempBeginParser("SPARTN_Test", parserTable, parserCount,
-                            buffer, bufferLength, processMessage, output);
+    parse = sempBeginParser("SPARTN_Test", parserTable, parserCount, buffer,
+                            bufferLength, processMessage, output, output);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 

--- a/examples/UBLOX_Test/UBLOX_Test.ino
+++ b/examples/UBLOX_Test/UBLOX_Test.ino
@@ -151,8 +151,8 @@ void setup()
     }
 
     // Initialize the parser
-    parse = sempBeginParser("UBLOX_Test", parserTable, parserCount,
-                            buffer, bufferLength, processMessage, output);
+    parse = sempBeginParser("UBLOX_Test", parserTable, parserCount, buffer,
+                            bufferLength, processMessage, output, output);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 

--- a/examples/Unicore_Binary_Test/Unicore_Binary_Test.ino
+++ b/examples/Unicore_Binary_Test/Unicore_Binary_Test.ino
@@ -204,6 +204,8 @@ void processMessage(SEMP_PARSE_STATE *parse, uint16_t type)
     {
         displayOnce = false;
         sempPrintLn(output);
+        sempUnicoreBinaryPrintHeader(parse);
+        sempPrintLn(output);
         sempPrintParserConfiguration(parse, output);
     }
 }

--- a/examples/Unicore_Binary_Test/Unicore_Binary_Test.ino
+++ b/examples/Unicore_Binary_Test/Unicore_Binary_Test.ino
@@ -148,8 +148,8 @@ void setup()
     }
 
     // Initialize the parser
-    parse = sempBeginParser("Unicore_Test", parserTable, parserCount,
-                            buffer, bufferLength, processMessage, output);
+    parse = sempBeginParser("Unicore_Test", parserTable, parserCount, buffer,
+                            bufferLength, processMessage, output, output);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 

--- a/examples/Unicore_Hash_Test/Unicore_Hash_Test.ino
+++ b/examples/Unicore_Hash_Test/Unicore_Hash_Test.ino
@@ -108,7 +108,7 @@ void setup()
     // Initialize the parser
     parse = sempBeginParser("Unicore_Hash_Test", parserTable, parserCount,
                             buffer, bufferLength, processMessage, output,
-                            &Serial, badUnicoreHashChecksum);
+                            output, &Serial, badUnicoreHashChecksum);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 

--- a/examples/Unicore_Hash_Test/Unicore_Hash_Test.ino
+++ b/examples/Unicore_Hash_Test/Unicore_Hash_Test.ino
@@ -108,7 +108,7 @@ void setup()
     // Initialize the parser
     parse = sempBeginParser("Unicore_Hash_Test", parserTable, parserCount,
                             buffer, bufferLength, processMessage, output,
-                            output, &Serial, badUnicoreHashChecksum);
+                            output, badUnicoreHashChecksum);
     if (!parse)
         reportFatalError("Failed to initialize the parser");
 

--- a/examples/User_Parser_Test/User_Parser_Test.ino
+++ b/examples/User_Parser_Test/User_Parser_Test.ino
@@ -88,7 +88,7 @@ void setup()
 
     // Initialize the parser
     parse = sempBeginParser("User_Parser", userParserTable, userParserCount,
-                            buffer, bufferLength, userMessage, output);
+                            buffer, bufferLength, userMessage, output, output);
     if (!parse)
         reportFatalError("Failed to initialize the user parser");
 

--- a/src/Parse_Unicore_Binary.cpp
+++ b/src/Parse_Unicore_Binary.cpp
@@ -301,25 +301,65 @@ SEMP_PARSER_DESCRIPTION sempUnicoreBinaryParserDescription =
 void sempUnicoreBinaryPrintHeader(SEMP_PARSE_STATE *parse)
 {
     SEMP_UNICORE_HEADER * header;
+    SEMP_OUTPUT output;
 
-    Print *print = parse->printError;
-    if (print)
+    output = sempGetErrorOutput(parse);
+    if (output)
     {
-        sempPrintln(print, "Unicore Message Header");
+        sempPrintStringLn(output, "Unicore Message Header");
         header = (SEMP_UNICORE_HEADER *)parse->buffer;
-        sempPrintf(print, "      0x%02x: Sync A", header->syncA);
-        sempPrintf(print, "      0x%02x: Sync B", header->syncB);
-        sempPrintf(print, "      0x%02x: Sync C", header->syncC);
-        sempPrintf(print, "      %3d%%: CPU Idle Time", header->cpuIdlePercent);
-        sempPrintf(print, "     %5d: Message ID", header->messageId);
-        sempPrintf(print, "     %5d: Message Length (bytes)", header->messageLength);
-        sempPrintf(print, "       %3d: Reference Time", header->referenceTime);
-        sempPrintf(print, "      0x%02x: Time Status", header->timeStatus);
-        sempPrintf(print, "     %5d: Week Number", header->weekNumber);
-        sempPrintf(print, "%10d: Seconds of Week", header->secondsOfWeek);
-        sempPrintf(print, "0x%08x: RESERVED", header->RESERVED);
-        sempPrintf(print, "       %3d: Release Version", header->releasedVersion);
-        sempPrintf(print, "       %3d: Leap Seconds", header->leapSeconds);
-        sempPrintf(print, "     %5d: Output Delay (mSec)", header->outputDelayMSec);
+        sempPrintString(output, "      ");
+        sempPrintHex0x02x(output, header->syncA);
+        sempPrintStringLn(output, ": Sync A");
+
+        sempPrintString(output, "      ");
+        sempPrintHex0x02x(output, header->syncB);
+        sempPrintStringLn(output, ": Sync B");
+
+        sempPrintString(output, "      ");
+        sempPrintHex0x02x(output, header->syncC);
+        sempPrintStringLn(output, ": Sync C");
+
+        sempPrintString(output, "      ");
+        sempPrintDecimalI32(output, header->cpuIdlePercent, 3);
+        sempPrintStringLn(output, "%: CPU Idle Time");
+
+        sempPrintString(output, "     ");
+        sempPrintDecimalI32(output, header->messageId, 5);
+        sempPrintStringLn(output, ": Message ID");
+
+        sempPrintString(output, "     ");
+        sempPrintDecimalU32(output, header->messageLength, 5);
+        sempPrintStringLn(output, ": Message Length (bytes)");
+
+        sempPrintString(output, "       ");
+        sempPrintDecimalI32(output, header->referenceTime, 3);
+        sempPrintStringLn(output, ": Reference Time");
+
+        sempPrintString(output, "      ");
+        sempPrintHex0x02x(output, header->timeStatus);
+        sempPrintStringLn(output, ": Time Status");
+
+        sempPrintString(output, "     ");
+        sempPrintDecimalI32(output, header->weekNumber, 5);
+        sempPrintStringLn(output, ": Week Number");
+
+        sempPrintDecimalI32(output, header->secondsOfWeek, 10);
+        sempPrintStringLn(output, ": Seconds of Week");
+
+        sempPrintHex0x08x(output, header->RESERVED);
+        sempPrintStringLn(output, ": RESERVED");
+
+        sempPrintString(output, "       ");
+        sempPrintDecimalI32(output, header->releasedVersion, 3);
+        sempPrintStringLn(output, ": Release Version");
+
+        sempPrintString(output, "       ");
+        sempPrintDecimalI32(output, header->leapSeconds, 3);
+        sempPrintStringLn(output, ": Leap Seconds");
+
+        sempPrintString(output, "     ");
+        sempPrintDecimalI32(output, header->outputDelayMSec, 5);
+        sempPrintStringLn(output, ": Output Delay (mSec)");
     }
 }

--- a/src/SparkFun_Extensible_Message_Parser.cpp
+++ b/src/SparkFun_Extensible_Message_Parser.cpp
@@ -399,6 +399,14 @@ size_t sempGetBufferLength(SEMP_PARSER_DESCRIPTION **parserTable,
 }
 
 //----------------------------------------
+// Get a path for an error character
+//----------------------------------------
+SEMP_OUTPUT sempGetErrorOutput(const SEMP_PARSE_STATE *parse)
+{
+    return parse->errorOutput ? parse->errorOutput : parse->debugOutput;
+}
+
+//----------------------------------------
 // Get a 32-bit floating point value
 //----------------------------------------
 float sempGetF4(const SEMP_PARSE_STATE *parse, uint16_t offset)

--- a/src/SparkFun_Extensible_Message_Parser.cpp
+++ b/src/SparkFun_Extensible_Message_Parser.cpp
@@ -81,6 +81,7 @@ SEMP_PARSE_STATE *sempBeginParser(
     uint8_t * buffer,
     size_t bufferLength,
     SEMP_EOM_CALLBACK eomCallback,
+    SEMP_OUTPUT errorOutput,
     SEMP_OUTPUT debugOutput,
     Print *printError,
     SEMP_BAD_CRC_CALLBACK badCrc
@@ -270,6 +271,15 @@ void sempErrorOutputDisable(SEMP_PARSE_STATE *parse)
 {
     if (parse)
         parse->printError = nullptr;
+}
+
+//----------------------------------------
+// Enable error output
+//----------------------------------------
+void sempErrorOutputEnable(SEMP_PARSE_STATE *parse, SEMP_OUTPUT output)
+{
+    if (parse)
+        parse->errorOutput = output;
 }
 
 //----------------------------------------

--- a/src/SparkFun_Extensible_Message_Parser.h
+++ b/src/SparkFun_Extensible_Message_Parser.h
@@ -129,7 +129,6 @@ typedef struct _SEMP_PARSE_STATE
     SEMP_INVALID_DATA_CALLBACK invalidData; // Invalid data callback
     const char *parserName;        // Name of parser table
     void *scratchPad;              // Parser scratchpad area
-    Print *printError;             // Class to use for error output
     SEMP_OUTPUT debugOutput;       // Output a debug character
     SEMP_OUTPUT errorOutput;       // Output an error character
     bool verboseDebug;             // Verbose debug output (default: false)
@@ -162,7 +161,6 @@ typedef struct _SEMP_PARSE_STATE
 //   oemCallback: Address of a callback routine to handle the parsed messages
 //   errorOutput: Address of a routine to output an error character, maybe nullptr
 //   debugOutput: Address of a routine to output a debug character, myabe nullptr
-//   printError: Addess of a routine used to output error messages
 //   badCrcCallback: Address of a routine to handle bad CRC messages
 //
 // Outputs:
@@ -201,11 +199,6 @@ typedef struct _SEMP_PARSE_STATE
 // are detected by a parser the name string value gets displayed to
 // identify the parse data structure associated with the error.  This
 // is helpful when multiple parsers are running at the same time.
-//
-// The printError value specifies a class address to use when printing
-// errors.  A nullptr value prevents any error from being output.  It is
-// possible to call sempSetPrintError later to enable or disable error
-// output.
 SEMP_PARSE_STATE * sempBeginParser(const char *parserTableName,
                                    SEMP_PARSER_DESCRIPTION **parseTable,
                                    uint16_t parserCount,
@@ -214,7 +207,6 @@ SEMP_PARSE_STATE * sempBeginParser(const char *parserTableName,
                                    SEMP_EOM_CALLBACK eomCallback,
                                    SEMP_OUTPUT errorOutput = nullptr,
                                    SEMP_OUTPUT debugOutput = nullptr,
-                                   Print *printError = &Serial,
                                    SEMP_BAD_CRC_CALLBACK badCrcCallback = (SEMP_BAD_CRC_CALLBACK)nullptr);
 
 // Disable debug output
@@ -1115,32 +1107,5 @@ void sempUnicoreHashAbortOnNonPrintable(SEMP_PARSE_STATE *parse, bool abort = tr
 // Outputs:
 //   Returns the address of a zero terminated sentence name string
 const char * sempUnicoreHashGetSentenceName(const SEMP_PARSE_STATE *parse);
-
-//------------------------------------------------------------------------------
-// V1 routines to be eliminated
-//------------------------------------------------------------------------------
-
-// Enable error output
-//
-// Inputs:
-//   parse: Address of a SEMP_PARSE_STATE structure
-//   print: Address of a Print object to use for output
-void sempEnableErrorOutput(SEMP_PARSE_STATE *parse,
-                           Print *print = &Serial);
-
-// Format and print a line of text
-//
-// Inputs:
-//   print: Address of a Print object to use for output
-//   format: Address of a zero terminated string of format characters
-//   ...: Parameters needed for the format
-void sempPrintf(Print *print, const char *format, ...);
-
-// Print a line of text
-//
-// Inputs:
-//   print: Address of a Print object to use for output
-//   string: Address of a zero terminated string of characters to output
-void sempPrintln(Print *print, const char *string = "");
 
 #endif  // __SPARKFUN_EXTENSIBLE_MESSAGE_PARSER_H__

--- a/src/SparkFun_Extensible_Message_Parser.h
+++ b/src/SparkFun_Extensible_Message_Parser.h
@@ -567,6 +567,15 @@ uint64_t sempGetU8NoOffset(const SEMP_PARSE_STATE *parse, size_t offset);
 // the incoming data stream
 //------------------------------------------------------------------------------
 
+// Get a path for an error character
+//
+// Inputs:
+//   parse: Address of a SEMP_PARSE_STATE structure
+//
+// Outputs:
+//   Returns the address of a routine to output an error character
+SEMP_OUTPUT sempGetErrorOutput(const SEMP_PARSE_STATE *parse);
+
 // Only parsers should call the routine sempFirstByte when an unexpected
 // byte is found in the data stream.  Parsers will also set the state
 // value to sempFirstByte after successfully parsing a message.  The

--- a/src/SparkFun_Extensible_Message_Parser.h
+++ b/src/SparkFun_Extensible_Message_Parser.h
@@ -131,6 +131,7 @@ typedef struct _SEMP_PARSE_STATE
     void *scratchPad;              // Parser scratchpad area
     Print *printError;             // Class to use for error output
     SEMP_OUTPUT debugOutput;       // Output a debug character
+    SEMP_OUTPUT errorOutput;       // Output an error character
     bool verboseDebug;             // Verbose debug output (default: false)
     uint32_t crc;                  // RTCM computed CRC
     uint8_t *buffer;               // Buffer containing the message
@@ -159,7 +160,8 @@ typedef struct _SEMP_PARSE_STATE
 //   buffer: Address of the buffer to be used for parser state, scratchpad
 //   bufferLength: Number of bytes in the buffer
 //   oemCallback: Address of a callback routine to handle the parsed messages
-//   debugOutput: Addess of a routine to output a debug character, myabe nullptr
+//   errorOutput: Address of a routine to output an error character, maybe nullptr
+//   debugOutput: Address of a routine to output a debug character, myabe nullptr
 //   printError: Addess of a routine used to output error messages
 //   badCrcCallback: Address of a routine to handle bad CRC messages
 //
@@ -210,6 +212,7 @@ SEMP_PARSE_STATE * sempBeginParser(const char *parserTableName,
                                    uint8_t * buffer,
                                    size_t bufferLength,
                                    SEMP_EOM_CALLBACK eomCallback,
+                                   SEMP_OUTPUT errorOutput = nullptr,
                                    SEMP_OUTPUT debugOutput = nullptr,
                                    Print *printError = &Serial,
                                    SEMP_BAD_CRC_CALLBACK badCrcCallback = (SEMP_BAD_CRC_CALLBACK)nullptr);
@@ -235,6 +238,13 @@ void sempDebugOutputEnable(SEMP_PARSE_STATE *parse,
 // Inputs:
 //   parse: Address of a SEMP_PARSE_STATE structure
 void sempErrorOutputDisable(SEMP_PARSE_STATE *parse);
+
+// Enable debug output
+//
+// Inputs:
+//   parse: Address of a SEMP_PARSE_STATE structure
+//   output: Address of a SEMP_OUTPUT routine to use for output
+void sempErrorOutputEnable(SEMP_PARSE_STATE *parse, SEMP_OUTPUT output);
 
 // Compute the necessary buffer length in bytes to support the scratch pad
 // and parse buffer lengths.


### PR DESCRIPTION
This PR includes the following changes:
* Add errorOutput to SEMP_PARSE_STATE and sempBeginParser
* Remove printError use from parsers
* Finish removing use of printError and references to the Print class